### PR TITLE
Fix Redis keyspace notifications for Myriad::Config

### DIFF
--- a/Changes
+++ b/Changes
@@ -11,6 +11,9 @@ Revision history for {{$dist->name}}
     to load and use the XS versions for better performance
     - Future::AsyncAwait::Hooks now available (for suspend/resume blocks) when using `:v2`
 
+    [Bugs fixed]
+    - handle keyspace notifications properly for config changes in Redis
+
 1.001     2022-11-11 09:42:07+08:00 Asia/Singapore
     [Bugs fixed]
     - Latest Future (and Future::XS) were failing tests due to `Future->needs_all`

--- a/lib/Myriad/Config.pm
+++ b/lib/Myriad/Config.pm
@@ -451,8 +451,8 @@ async method listen_for_updates () {
             })->resolve->completed->retain->on_fail(sub {
                 $log->warnf('Config: config updates listener failed - %s', shift);
             });
-        } catch {
-            $log->trace('Config: transport does not support keyspace notifications');
+        } catch ($e) {
+            $log->tracef('Config: transport does not support keyspace notifications: %s', $e);
         }
     } else {
         $log->warn('Config: Storage is not initiated, cannot listen to config updates');

--- a/lib/Myriad/Transport/Redis.pm
+++ b/lib/Myriad/Transport/Redis.pm
@@ -733,28 +733,22 @@ async method zrange ($k, @v) {
 }
 
 async method watch_keyspace($pattern) {
-    my $sub;
-    if ($clientside_cache_size) {
-        # Net::Async::Redis will handl the connection in this case
-        $sub = $redis->clientside_cache_events->map(sub {
-            $_ =~ s/$prefix\.//;
-            return $_;
-        });
-    } else {
-        # Keyspace notification is a psubscribe
-        my $instance = await $self->borrow_instance_from_pool;
-        $sub = await $instance->watch_keyspace($self->apply_prefix($pattern));
+    # Net::Async::Redis will handl the connection in this case
+    return $redis->clientside_cache_events->map(sub {
+        return s/^$prefix\.//r;
+    }) if $clientside_cache_size;
 
-        $sub = $sub->events->map(sub {
-            $_->{channel} =~ s/__key.*:$prefix\.//;
-            return $_->{channel};
-        });
-
-        $sub->on_ready(sub {
-            $self->return_instance_to_pool($instance);
-        });
-    }
-
+    # Keyspace notification is a psubscribe
+    my $instance = await $self->borrow_instance_from_pool;
+    my $sub = (await $instance->watch_keyspace(
+        $self->apply_prefix($pattern)
+    ))->map(sub {
+        my $chan = $_->{channel} =~ s/__key.*:$prefix\.//r;
+        return $chan;
+    });
+    $sub->on_ready($self->$curry::weak(sub {
+        shift->return_instance_to_pool($instance);
+    }));
     return $sub;
 }
 


### PR DESCRIPTION
Configuration updates had two mechanisms for notifying the Myriad::Config observables on change:

- clientside cache key tracking
- keyspace notifications

The keyspace notifications were failing due to an incorrect assumption about the returned object, and this failure was hidden by a log message which left out the exception details.