### PR TITLE
The `extends` option should load the module if not already available

### DIFF
--- a/lib/Myriad/Class.pm
+++ b/lib/Myriad/Class.pm
@@ -271,6 +271,7 @@ sub import {
         # ... and then _again_ to disable the experimental warnings
         Object::Pad->import_into($pkg, qw(:experimental));
         my $method = 'begin_' . ($args{type} || 'class');
+        Module::Load::load($args{extends}) if $args{extends};
         my $meta = Object::Pad::MOP::Class->$method(
             $class,
             (


### PR DESCRIPTION
Currently, this:

```perl
package Example;
use Deriv::Class extends => qw(Some::Parent);
```

will not load `Some::Parent` automatically, and this can lead to some peculiar and hard-to-trace errors. Since we're loading modules in other cases, we should be doing this for `extends` as well.