### PR TITLE
Update to latest CPAN modules

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -3,19 +3,19 @@ requires 'mro';
 requires 'indirect';
 requires 'multidimensional';
 requires 'bareword::filehandles';
-requires 'XS::Parse::Keyword', '>= 0.33';
+requires 'XS::Parse::Keyword', '>= 0.38';
 requires 'Syntax::Keyword::Dynamically', '>= 0.12';
-requires 'Syntax::Keyword::Try', '>= 0.28';
-requires 'Syntax::Keyword::Defer', '>= 0.08';
-requires 'Syntax::Keyword::Match', '>= 0.10';
-requires 'Syntax::Operator::Equ', '>= 0.05';
+requires 'Syntax::Keyword::Try', '>= 0.29';
+requires 'Syntax::Keyword::Defer', '>= 0.09';
+requires 'Syntax::Keyword::Match', '>= 0.13';
+requires 'Syntax::Operator::Equ', '>= 0.06';
 requires 'Future', '>= 0.50';
 requires 'Future::Queue';
-requires 'Future::AsyncAwait', '>= 0.65';
+requires 'Future::AsyncAwait', '>= 0.66';
 requires 'Future::AsyncAwait::Hooks', '>= 0.02';
-requires 'Future::IO', '>= 0.13';
-requires 'XS::Parse::Sublike', '>= 0.16';
-requires 'Object::Pad', '>= 0.78';
+requires 'Future::IO', '>= 0.14';
+requires 'XS::Parse::Sublike', '>= 0.20';
+requires 'Object::Pad', '>= 0.803';
 requires 'Role::Tiny', '>= 2.002004';
 # Streams
 requires 'Ryu', '>= 3.004';
@@ -25,14 +25,14 @@ requires 'Heap', '>= 0.80';
 requires 'IO::Async', '>= 0.802';
 requires 'IO::Async::Notifier', '>= 0.802';
 requires 'IO::Async::Test', '>= 0.802';
-requires 'IO::Async::SSL', '>= 0.24';
+requires 'IO::Async::SSL', '>= 0.25';
 # Functionality
 requires 'curry', '>= 2.000001';
 requires 'Log::Any', '>= 1.710';
 requires 'Log::Any::Adapter', '>= 1.710';
-requires 'Config::Any', '>= 0.32';
-requires 'YAML::XS', '>= 0.86';
-requires 'Metrics::Any', '>= 0.09';
+requires 'Config::Any', '>= 0.33';
+requires 'YAML::XS', '>= 0.88';
+requires 'Metrics::Any', '>= 0.10';
 requires 'OpenTracing::Any', '>= 1.006';
 requires 'JSON::MaybeUTF8', '>= 2.000';
 requires 'Unicode::UTF8';
@@ -49,16 +49,16 @@ requires 'Math::Random::Secure';
 requires 'Getopt::Long';
 requires 'Pod::Usage';
 requires 'List::Util', '>= 1.63';
-requires 'List::Keywords', '>= 0.10';
+requires 'List::Keywords', '>= 0.11';
 # Integration
 requires 'Net::Async::OpenTracing', '>= 1.001';
 requires 'Log::Any::Adapter::OpenTracing', '>= 0.001';
 requires 'Metrics::Any::Adapter::Statsd', '>= 0.03';
 # Transport
-requires 'Net::Async::Redis', '>= 3.022';
+requires 'Net::Async::Redis', '>= 4.001';
 recommends 'Net::Async::Redis::XS', '>= 0.007';
-requires 'Net::Async::HTTP', '>= 0.48';
-requires 'Net::Async::HTTP::Server', '>= 0.13';
+requires 'Net::Async::HTTP', '>= 0.49';
+requires 'Net::Async::HTTP::Server', '>= 0.14';
 # Introspection
 requires 'Devel::MAT::Dumper';
 


### PR DESCRIPTION
There have been [performance improvements](https://metacpan.org/release/PEVANS/Object-Pad-0.803/source/Changes) in Object::Pad object creation, various fixes and improvements to Redis cluster handling plus the latest 7.2 command list (https://metacpan.org/release/TEAM/Net-Async-Redis-4.000/source/Changes), and syntax improvements for the operators and match/case modules as well.