### PR TITLE
Mutex support

### DIFF
--- a/lib/Myriad/API.pm
+++ b/lib/Myriad/API.pm
@@ -26,6 +26,7 @@ use Myriad::Service::Remote;
 use Myriad::Service::Storage;
 
 field $myriad;
+field $service;
 field $service_name;
 field $storage;
 field $config;
@@ -36,6 +37,7 @@ field $config;
 
 BUILD (%args) {
     weaken($myriad = delete $args{myriad});
+    weaken($service = delete $args{service});
     $service_name = delete $args{service_name} // die 'need a service name';
     $config = delete $args{config} // {};
     $storage = Myriad::Service::Storage->new(

--- a/lib/Myriad/API.pm
+++ b/lib/Myriad/API.pm
@@ -21,6 +21,7 @@ storage, subscription and RPC behaviour.
 =cut
 
 use Myriad::Config;
+use Myriad::Mutex;
 use Myriad::Service::Remote;
 use Myriad::Service::Storage;
 
@@ -80,6 +81,19 @@ method config ($key) {
         return $config->{$key};
     }
     Myriad::Exception::Config::UnregisteredConfig->throw(reason => "$key is not registred by service $service_name");
+}
+
+=head2 mutex
+
+=cut
+
+async method mutex (%args) {
+    $args{key} = delete($args{name}) // $service_name;
+    my $mutex = Myriad::Mutex->new(
+        %args,
+        redis => $storage->redis,
+    );
+    return await $mutex->acquire;
 }
 
 1;

--- a/lib/Myriad/API.pm
+++ b/lib/Myriad/API.pm
@@ -92,10 +92,11 @@ method config ($key) {
 
 async method mutex (@args) {
     my ($code) = extract_by { ref($_) eq 'CODE' } @args;
-    my ($name) = @args;
-    $name //= $service_name;
+    my $name = @args % 2 ? shift(@args) : $service_name;
+    my %args = @args;
     $log->infof('Service = %s', "$service");
     my $mutex = Myriad::Mutex->new(
+        %args,
         key     => $name,
         storage => $storage,
         id      => $service->uuid,

--- a/lib/Myriad/Mutex.pm
+++ b/lib/Myriad/Mutex.pm
@@ -1,0 +1,64 @@
+package Myriad::Mutex;
+use Myriad::Class qw(:v2);
+
+use Math::Random::Secure;
+
+field $key;
+field $id;
+field $storage;
+
+field $acquired;
+
+BUILD (%args) {
+    $id = delete $args{id};
+    $key = delete $args{key};
+    $storage = delete $args{storage};
+    die 'invalid remaining keys in %args - '. join ',', sort keys %args if %args;
+}
+
+async method removal_watch {
+}
+
+async method acquire {
+    while(1) {
+        if(
+            my $res = await $storage->set_unless_exists(
+                $key => $id,
+                3.0,
+            )
+        ) {
+            $log->debug('Mutex [%s] lost to [%s]', $key, $res);
+            my $removed = $storage->when_key_changed($key);
+            await $removed if await $storage->get($key);
+        } else {
+            $log->debugf('Acquired mutex [%s]', $key);
+            $acquired = 1;
+            return $self;
+        }
+    }
+}
+
+async method release {
+    return unless $acquired;
+    $log->debugf('Release mutex [%s]', $key);
+    await $storage->del($key);
+}
+
+method DESTROY {
+    $self->release->retain;
+}
+
+1;
+
+__END__
+
+=head1 AUTHOR
+
+Deriv Group Services Ltd. C<< DERIV@cpan.org >>.
+
+See L<Myriad/CONTRIBUTORS> for full details.
+
+=head1 LICENSE
+
+Copyright Deriv Group Services Ltd 2020-2024. Licensed under the same terms as Perl itself.
+

--- a/lib/Myriad/Mutex.pm
+++ b/lib/Myriad/Mutex.pm
@@ -23,6 +23,7 @@ use Math::Random::Secure;
 field $key;
 field $id;
 field $storage;
+field $ttl;
 
 field $acquired;
 
@@ -30,6 +31,7 @@ BUILD (%args) {
     $id = delete $args{id};
     $key = delete $args{key};
     $storage = delete $args{storage};
+    $ttl = delete $args{ttl} // 60;
     die 'invalid remaining keys in %args - '. join ',', sort keys %args if %args;
 }
 
@@ -41,7 +43,7 @@ async method acquire {
         if(
             my $res = await $storage->set_unless_exists(
                 $key => $id,
-                3.0,
+                $ttl,
             )
         ) {
             $log->debugf('Mutex [%s] lost to [%s]', $key, $res);

--- a/lib/Myriad/Mutex.pm
+++ b/lib/Myriad/Mutex.pm
@@ -1,6 +1,23 @@
 package Myriad::Mutex;
 use Myriad::Class qw(:v2);
 
+# VERSION
+# AUTHORITY
+
+=encoding utf8
+
+=head1 NAME
+
+Myriad::Mutex - a basic mutual-exclusion primitive
+
+=head1 SYNOPSIS
+
+ my $mutex = await $api->mutex;
+
+=head1 DESCRIPTION
+
+=cut
+
 use Math::Random::Secure;
 
 field $key;

--- a/lib/Myriad/Mutex.pm
+++ b/lib/Myriad/Mutex.pm
@@ -56,9 +56,11 @@ async method acquire {
 }
 
 async method release {
-    return unless $acquired;
+    return undef unless $acquired;
     $log->debugf('Release mutex [%s]', $key);
     await $storage->del($key);
+    $acquired = 0;
+    return undef;
 }
 
 method DESTROY {

--- a/lib/Myriad/Mutex.pm
+++ b/lib/Myriad/Mutex.pm
@@ -44,7 +44,7 @@ async method acquire {
                 3.0,
             )
         ) {
-            $log->debug('Mutex [%s] lost to [%s]', $key, $res);
+            $log->debugf('Mutex [%s] lost to [%s]', $key, $res);
             my $removed = $storage->when_key_changed($key);
             await $removed if await $storage->get($key);
         } else {

--- a/lib/Myriad/Registry.pm
+++ b/lib/Myriad/Registry.pm
@@ -65,6 +65,7 @@ async method add_service (%args) {
     $myriad->storage;
     $myriad->on_start(async sub {
         $Myriad::Service::SLOT{$pkg}{api}->value($srv) = Myriad::API->new(
+            service => $srv,
             myriad => $myriad,
             service_name => $service_name,
             config => await $myriad->config->service_config($pkg, $service_name),

--- a/lib/Myriad/Role/Storage.pm
+++ b/lib/Myriad/Role/Storage.pm
@@ -45,7 +45,7 @@ a concrete implementation - instead, see classes such as:
 
 =cut
 
-our @WRITE_METHODS = qw(set getset getdel incr push unshift pop shift hash_set hash_add orderedset_add orderedset_remove_member orderedset_remove_byscore del unlink);
+our @WRITE_METHODS = qw(set getset getdel incr push unshift pop shift hash_set hash_add orderedset_add orderedset_remove_member orderedset_remove_byscore del unlink set_unless_exists);
 
 =head2 set
 
@@ -258,12 +258,13 @@ method orderedset_remove_byscore;
 
 method del;
 method unlink;
+method set_unless_exists;
 
 =head1 METHODS - Read
 
 =cut
 
-our @READ_METHODS = qw(get observe watch_keyspace hash_get hash_keys hash_values hash_exists hash_count hash_as_list orderedset_member_count orderedset_members);
+our @READ_METHODS = qw(get observe watch_keyspace hash_get hash_keys hash_values hash_exists hash_count hash_as_list orderedset_member_count orderedset_members when_key_changed);
 
 =head2 get
 
@@ -429,6 +430,8 @@ Returns a L<Future>.
 =cut
 
 method orderedset_members;
+
+method when_key_changed;
 
 1;
 

--- a/lib/Myriad/Role/Storage.pm
+++ b/lib/Myriad/Role/Storage.pm
@@ -45,7 +45,7 @@ a concrete implementation - instead, see classes such as:
 
 =cut
 
-our @WRITE_METHODS = qw(set getset getdel incr push unshift pop shift hash_set hash_add orderedset_add orderedset_remove_member orderedset_remove_byscore );
+our @WRITE_METHODS = qw(set getset getdel incr push unshift pop shift hash_set hash_add orderedset_add orderedset_remove_member orderedset_remove_byscore del unlink);
 
 =head2 set
 
@@ -255,6 +255,9 @@ Returns a L<Future>.
 =cut
 
 method orderedset_remove_byscore;
+
+method del;
+method unlink;
 
 =head1 METHODS - Read
 

--- a/lib/Myriad/Service/Implementation.pm
+++ b/lib/Myriad/Service/Implementation.pm
@@ -19,6 +19,7 @@ Myriad::Service::Implementation - microservice coördination
 
 use Myriad::Storage::Implementation::Redis;
 use Myriad::Subscription;
+use Myriad::Util::UUID;
 
 use Myriad::Service::Attributes;
 
@@ -39,6 +40,8 @@ field $storage;
 field $myriad;
 field $service_name;
 field %active_batch;
+
+field $uuid : reader { Myriad::Util::UUID::uuid() }
 
 =head1 ATTRIBUTES
 

--- a/lib/Myriad/Storage/Implementation/Memory.pm
+++ b/lib/Myriad/Storage/Implementation/Memory.pm
@@ -76,7 +76,15 @@ async method set : Defer ($k, $v, $ttl = undef) {
     return $v;
 }
 
-async method when_key_changed ($k) {
+async method set_unless_exists : Defer ($k, $v, $ttl = undef) {
+    die 'value cannot be a reference for ' . $k . ' - ' . ref($v) if ref $v;
+    return $data{$k} if exists $data{$k};
+    $data{$k} = $v;
+    $key_change->{$k}->done if $key_change->{$k};
+    return $v;
+}
+
+method when_key_changed ($k) {
     return +(
         $key_change->{$k} //= $self->loop->new_future->on_ready($self->$curry::weak(method {
             delete $key_change->{$k}

--- a/lib/Myriad/Storage/Implementation/Memory.pm
+++ b/lib/Myriad/Storage/Implementation/Memory.pm
@@ -25,6 +25,8 @@ correctly.
 # Common datastore
 field %data;
 
+field $key_change { +{ } }
+
 # FIXME Need to update :Defer for Object::Pad
 sub MODIFY_CODE_ATTRIBUTES { }
 
@@ -69,7 +71,17 @@ Returns a L<Future> which will resolve on completion.
 
 async method set : Defer ($k, $v, $ttl = undef) {
     die 'value cannot be a reference for ' . $k . ' - ' . ref($v) if ref $v;
-    return $data{$k} = $v;
+    $data{$k} = $v;
+    $key_change->{$k}->done if $key_change->{$k};
+    return $v;
+}
+
+async method when_key_changed ($k) {
+    return +(
+        $key_change->{$k} //= $self->loop->new_future->on_ready($self->$curry::weak(method {
+            delete $key_change->{$k}
+        }))
+    )->without_cancel;
 }
 
 =head2 getset
@@ -464,7 +476,18 @@ async method orderedset_remove_byscore : Defer ($k, $min, $max) {
     $data{$k} = { map { ($_ >= $min and $_ <= $max ) ? () : ($_ => $data{$k}->{$_})  } keys $data{$k}->%* };
     my @keys_after = keys $data{$k}->%*;
     return 0 + @keys_before - @keys_after;
+}
 
+async method unlink : Defer (@keys) {
+    delete @data{@keys};
+    $key_change->{$_}->done for grep { $key_change->{$_} } @keys;
+    return $self;
+}
+
+async method del : Defer (@keys) {
+    delete @data{@keys};
+    $key_change->{$_}->done for grep { $key_change->{$_} } @keys;
+    return $self;
 }
 
 =head2 orderedset_member_count

--- a/lib/Myriad/Storage/Implementation/Memory.pm
+++ b/lib/Myriad/Storage/Implementation/Memory.pm
@@ -78,10 +78,11 @@ async method set : Defer ($k, $v, $ttl = undef) {
 
 async method set_unless_exists : Defer ($k, $v, $ttl = undef) {
     die 'value cannot be a reference for ' . $k . ' - ' . ref($v) if ref $v;
+    my $old = $data{$k};
     return $data{$k} if exists $data{$k};
     $data{$k} = $v;
     $key_change->{$k}->done if $key_change->{$k};
-    return $v;
+    return $old;
 }
 
 method when_key_changed ($k) {

--- a/lib/Myriad/Storage/Implementation/Redis.pm
+++ b/lib/Myriad/Storage/Implementation/Redis.pm
@@ -519,12 +519,12 @@ async method orderedset_remove_byscore ($k, $min, $max) {
 }
 
 async method unlink (@keys) {
-    await $redis->unlink(@keys);
+    await $redis->unlink(map { $self->apply_prefix($_) } @keys);
     return $self;
 }
 
 async method del (@keys) {
-    await $redis->del(@keys);
+    await $redis->del(map { $self->apply_prefix($_) } @keys);
     return $self;
 }
 

--- a/lib/Myriad/Storage/Implementation/Redis.pm
+++ b/lib/Myriad/Storage/Implementation/Redis.pm
@@ -30,11 +30,16 @@ field $redis;
 # L<Future>s which complete when there's a change notification for the given key
 field $key_change { +{ } }
 
+field $key_watcher;
+
 BUILD (%args) {
     $redis = delete $args{redis} // die 'need a Transport instance';
-    $redis->clientside_cache_events
+}
+
+method key_watcher {
+    $key_watcher ||= $redis->clientside_cache_events
         ->each($self->$curry::weak(method {
-            $log->debugf('Key change detected for %s', $_);
+            $log->infof('Key change detected for %s', $_);
             $key_change->{$_}->done if $key_change->{$_};
             return;
         }));

--- a/lib/Myriad/Storage/Implementation/Redis.pm
+++ b/lib/Myriad/Storage/Implementation/Redis.pm
@@ -111,10 +111,9 @@ async method set ($k, $v, $ttl = undef) {
 
 async method set_unless_exists ($k, $v, $ttl = undef) {
     die 'value cannot be a reference for ' . $k . ' - ' . ref($v) if ref $v;
-    await $redis->set(
+    await $redis->set_unless_exists(
         $self->apply_prefix($k) => $v,
-        qw(NX GET), 
-        ($ttl ? (PX => $ttl * 1000.0) : ())
+        $ttl,
     );
 }
 

--- a/lib/Myriad/Transport/Redis.pm
+++ b/lib/Myriad/Transport/Redis.pm
@@ -644,6 +644,24 @@ async method set ($key, $v, $ttl) {
     await $redis->set($self->apply_prefix($key), $v, defined $ttl ? ('EX', $ttl) : ());
 }
 
+async method unlink (@keys) {
+    await $redis->unlink(map { $self->apply_prefix($_) } @keys);
+}
+
+async method del (@keys) {
+    await $redis->del(map { $self->apply_prefix($_) } @keys);
+}
+
+async method set_unless_exists ($key, $v, $ttl) {
+    $log->infof('Set [%s] to %s with TTL %s', $key, $v, $ttl);
+    await $redis->set(
+        $self->apply_prefix($key),
+        $v,
+        qw(NX GET), 
+        defined $ttl ? ('PX', $ttl * 1000.0) : ()
+    );
+}
+
 async method getset($key, $v) {
     await $redis->getset($self->apply_prefix($key), $v);
 }

--- a/lib/Myriad/Transport/Redis.pm
+++ b/lib/Myriad/Transport/Redis.pm
@@ -140,8 +140,7 @@ method apply_prefix($key) {
 =cut
 
 method remove_prefix($key) {
-    $key =~ s/^\Q$prefix\E\.//;
-    return $key;
+    return $key =~ s/^\Q$prefix\E\.//r;
 }
 
 =head2 oldest_processed_id

--- a/lib/Myriad/Transport/Redis.pm
+++ b/lib/Myriad/Transport/Redis.pm
@@ -132,7 +132,7 @@ async method start {
 =cut
 
 method apply_prefix($key) {
-    $key =~ /^$prefix\./ ? $key : "$prefix.$key";
+    return "$prefix.$key";
 }
 
 =head2 remove_prefix

--- a/lib/Myriad/Transport/Redis.pm
+++ b/lib/Myriad/Transport/Redis.pm
@@ -78,6 +78,8 @@ field $clientside_cache_size;
 field $prefix;
 field $ryu;
 
+field $cache_events;
+
 BUILD {
     $redis_pool = [];
     $waiting_redis_pool = [];
@@ -721,6 +723,11 @@ async method zcount ($k, $min, $max) {
 
 async method zrange ($k, @v) {
     await $redis->zrange($self->apply_prefix($k), @v);
+}
+
+method clientside_cache_events {
+    $cache_events ||= $redis->clientside_cache_events
+        ->map($self->curry::weak::remove_prefix)
 }
 
 async method watch_keyspace ($pattern) {

--- a/lib/Myriad/Transport/Redis.pm
+++ b/lib/Myriad/Transport/Redis.pm
@@ -749,9 +749,10 @@ method clientside_cache_events {
 
 async method watch_keyspace ($pattern) {
     # Net::Async::Redis will handle the connection in this case
-    return $redis->clientside_cache_events->map(sub {
-        return s/^$prefix\.//r;
-    }) if $clientside_cache_size;
+    return $redis->clientside_cache_events->map($self->$curry::weak(method {
+        $log->tracef('Have clientside cache event with [%s] and will remove prefix [%s.]', $_, $prefix);
+        return $self->remove_prefix($_);
+    })) if $clientside_cache_size;
 
     $log->tracef(
         'Falling back to keyspace notifications for %s due to client cache size = %d or unsupported',

--- a/lib/Myriad/Util/Defer.pm
+++ b/lib/Myriad/Util/Defer.pm
@@ -49,9 +49,9 @@ sub defer_method ($package, $name, $fqdn) {
         # either zero (default behaviour) or if we have a random
         # delay assigned, use that to drive a uniform rand() call
         $log->tracef('call to %s::%s, deferring start', $package, $name);
-        await $self->loop->delay_future(
+        await RANDOM_DELAY ? $self->loop->delay_future(
             after => rand(RANDOM_DELAY)
-        );
+        ) : $self->loop->later;
 
         $log->tracef('deferred call to %s::%s runs now', $package, $name);
 


### PR DESCRIPTION
Extracting out the `$api->mutex` method from https://github.com/deriv-com/perl-Myriad/pull/300.

This provides a basic mutex-with-timeout primitive which can be used to ensure only one worker is actively running the code block at a time.

It's mainly intended for multiple-worker API calls and database operations where we don't want to flood third-party APIs with requests from multiple active workers, but _do_ want basic high-availability handling in case some workers run into problems.
