### PR TITLE
bugfix/trim_prefix

### DIFF
--- a/lib/Myriad/Transport/Redis.pm
+++ b/lib/Myriad/Transport/Redis.pm
@@ -314,7 +314,11 @@ async method cleanup (%args) {
         my $oldest = await $self->oldest_processed_id($stream);
         $log->tracef('Attempting to clean up [%s] Size: %d | Earliest ID to care about: %s', $stream, $info->{length}, $oldest);
         if ($oldest and $oldest ne '0-0' and $self->compare_id($oldest, $info->{first_entry}[0]) > 0) {
-            my ($total) = await $redis->xtrim($stream, MINID => ($use_trim_exact ? () : '~'), $oldest);
+            my ($total) = await $redis->xtrim(
+                $stream,
+                MINID => ($use_trim_exact ? () : '~'),
+                $oldest
+            );
             $log->tracef('Trimmed %d items from stream: %s', $total, $stream);
         }
         else {

--- a/lib/Myriad/Transport/Redis.pm
+++ b/lib/Myriad/Transport/Redis.pm
@@ -315,7 +315,7 @@ async method cleanup (%args) {
         $log->tracef('Attempting to clean up [%s] Size: %d | Earliest ID to care about: %s', $stream, $info->{length}, $oldest);
         if ($oldest and $oldest ne '0-0' and $self->compare_id($oldest, $info->{first_entry}[0]) > 0) {
             my ($total) = await $redis->xtrim(
-                $stream,
+                $self->apply_prefix($stream),
                 MINID => ($use_trim_exact ? () : '~'),
                 $oldest
             );


### PR DESCRIPTION
When trimming old entries from the stream, we were applying the wrong prefix to the key as a result of the earlier changes to support approximate/exact trimming.