### PR TITLE
feature/batch_ack

### DIFF
--- a/lib/Myriad/Subscription/Implementation/Redis.pm
+++ b/lib/Myriad/Subscription/Implementation/Redis.pm
@@ -182,11 +182,7 @@ async method receive_items {
                         $sink->source->emit({
                             data => $event_data
                         });
-                        await $redis->ack(
-                            $stream,
-                            $group_name,
-                            $event->{id}
-                        );
+                        push @pending, $event->{id};
                         $span->set_status(
                             SPAN_STATUS_OK
                         );

--- a/lib/Myriad/Subscription/Implementation/Redis.pm
+++ b/lib/Myriad/Subscription/Implementation/Redis.pm
@@ -142,11 +142,10 @@ async method receive_items {
             while(@pending) {
                 # IDs are quite short, so we can stuff a fair few into each command - there's a bit of
                 # overhead so the more we combine here the better
-                my @ids = splice @pending, 0, min(0+@pending, 200);
                 push @ack, $redis->ack(
                     $stream,
                     $group_name,
-                    @ids
+                    splice(@pending, 0, min(0+@pending, 200))
                 );
             }
             my @events = await $redis->read_from_stream(

--- a/lib/Myriad/Subscription/Implementation/Redis.pm
+++ b/lib/Myriad/Subscription/Implementation/Redis.pm
@@ -137,7 +137,6 @@ async method receive_items {
                 await $self->loop->delay_future(after => 5);
                 next;
             }
-            await $sink->unblocked;
             my @ack;
             while(@pending) {
                 # IDs are quite short, so we can stuff a fair few into each command - there's a bit of
@@ -145,9 +144,13 @@ async method receive_items {
                 push @ack, $redis->ack(
                     $stream,
                     $group_name,
-                    splice(@pending, 0, min(0+@pending, 200))
+                    splice(
+                        @pending, 0, min(0+@pending, 200)
+                    )
                 );
             }
+
+            await $sink->unblocked;
             my @events = await $redis->read_from_stream(
                 stream => $stream,
                 group  => $group_name,

--- a/lib/Myriad/Subscription/Implementation/Redis.pm
+++ b/lib/Myriad/Subscription/Implementation/Redis.pm
@@ -142,7 +142,7 @@ async method receive_items {
             while(@pending) {
                 # IDs are quite short, so we can stuff a fair few into each command - there's a bit of
                 # overhead so the more we combine here the better
-                my @ids = splice @pending, min(0+@pending, 200);
+                my @ids = splice @pending, 0, min(0+@pending, 200);
                 push @ack, $redis->ack(
                     $stream,
                     $group_name,

--- a/lib/Myriad/Transport/Redis.pm
+++ b/lib/Myriad/Transport/Redis.pm
@@ -637,8 +637,8 @@ Acknowledge a message from a Redis stream.
 
 =cut
 
-async method ack ($stream, $group, $message_id) {
-    await $redis->xack($self->apply_prefix($stream), $group, $message_id);
+async method ack ($stream, $group, @message_ids) {
+    await $redis->xack($self->apply_prefix($stream), $group, @message_ids);
 }
 
 =head2 publish


### PR DESCRIPTION
When subscription or RPC items have been processed, the Redis implementation was issuing a separate `XACK` for every ID. This can lead to a lot of network traffic and unnecessary delay between completing items and receiving new ones.

The change here combines multiple IDs into a single `XACK` call, meaning that we are now closer to symmetry between the `XREADGROUP` to get the work, and the `XACK` to report completion. The ordering is also changed so that we avoid a roundtrip before we can start receiving items: instead, we issue all the `XACK`s and immediately request the `XREADGROUP`.