### PR TITLE
feature/configurable_backlog

### DIFF
--- a/lib/Myriad/Service/Implementation.pm
+++ b/lib/Myriad/Service/Implementation.pm
@@ -258,6 +258,7 @@ async method load () {
                 source  => $spec->{src}->pause,
                 channel => $chan,
                 service => $service_name,
+                max_len => $spec->{args}{max_len},
             );
         }
     }

--- a/lib/Myriad/Subscription/Implementation/Redis.pm
+++ b/lib/Myriad/Subscription/Implementation/Redis.pm
@@ -245,7 +245,7 @@ async method check_for_overflow () {
         }
 
         # No need to run vigorously
-        await $self->loop->delay_future(after => 5)
+        await $self->loop->delay_future(after => 5 + rand)
     }
 }
 


### PR DESCRIPTION
Allow `Emitter`s to request a specific queue length, via `max_len`. This is then used when deciding when to pause or clean up, and allows shorter/longer backlog than the `10k` default.

To make this useful, the cleanup via `XTRIM` now applies the cleanup in batches, to avoid locking the server for extended amounts of time on larger streams. It also applies exact cleanup if the approximate cleanup couldn't find anything to remove and we're blocked waiting for progress, so that smaller streams can be used without deadlock.