### PR TITLE
bugfix/transport_activation

### DIFF
--- a/lib/Myriad/Commands.pm
+++ b/lib/Myriad/Commands.pm
@@ -76,6 +76,14 @@ async method service (@args) {
         }
     }
 
+    # Ensure we have valid transports in place before we start
+    for my $type (qw(storage subscription rpc)) {
+        $log->tracef('Set up transport for [%s]', $type);
+        my $method = $myriad->config->${\"${type}_transport"}->as_string . '_transport';
+        my $instance = $myriad->$method;
+        await $instance->start if $instance->can('start');
+    }
+
     # Load services into Myriad but don't start them yet
 
     $log->tracef('Attempt to add services for %s', join ',', @services_modules);


### PR DESCRIPTION
At startup, we were not checking whether our transports (Redis, PostgreSQL etc.) were ready. This could cause early actions to fail due to objects not being defined or ready for queries.

To fix this, we run the `->start` method on all transports and wait for it to respond before the rest of the command processing. This will cause early exit if there are connectivity issues, and removes the startup race condition.