### PR TITLE
feature/stream_extra

### DIFF
--- a/lib/Myriad/Subscription/Implementation/Redis.pm
+++ b/lib/Myriad/Subscription/Implementation/Redis.pm
@@ -174,7 +174,7 @@ async method receive_items {
                             parent => OpenTelemetry::Context->current,
                             name   => $stream,
                             attributes => {
-                                args => $event->{data}[1]
+                                args => $event->{data}
                             },
                         );
                     }
@@ -182,7 +182,7 @@ async method receive_items {
                         if(USE_OPENTELEMETRY) {
                             my $context = OpenTelemetry::Trace->context_with_span($span);
                             dynamically OpenTelemetry::Context->current = $context;
-                            my $event_data = decode_json_utf8($event->{data}->[1]);
+                            my $event_data = decode_json_utf8($event->{data});
                             $log->tracef('Passing event: %s | from stream: %s to subscription sink: %s', $event_data, $stream, $sink->label);
                             $sink->source->emit({
                                 data => $event_data
@@ -192,7 +192,7 @@ async method receive_items {
                                 SPAN_STATUS_OK
                             );
                         } else {
-                            my $event_data = decode_json_utf8($event->{data}->[1]);
+                            my $event_data = decode_json_utf8($event->{data});
                             $log->tracef('Passing event: %s | from stream: %s to subscription sink: %s', $event_data, $stream, $sink->label);
                             $sink->source->emit({
                                 data => $event_data


### PR DESCRIPTION
Allow multiple keys for RPC and subscription streams. This is to allow for metadata and alternative compression/encoding formats in future.

We also add exception handling for subscription stream processing, since the logic around reading+processing items is starting to become more complicated.