### PR TITLE
Provide a proxy class to make method calls neater

### DIFF
--- a/lib/Myriad/Service/Remote.pm
+++ b/lib/Myriad/Service/Remote.pm
@@ -20,6 +20,7 @@ Myriad::Service::Remote - abstraction to access other services over the network.
 
 use Myriad::Class;
 use Myriad::Service::Storage::Remote;
+use Myriad::Service::Remote::RPC;
 
 field $myriad;
 field $service_name;
@@ -66,6 +67,13 @@ it takes
 
 async method call_rpc ($rpc, %args) {
     await $myriad->rpc_client->call_rpc($service_name, $rpc, %args);
+}
+
+method rpc () {
+    return Myriad::Service::Remote::RPC->new(
+        myriad  => $myriad,
+        service => $service_name,
+    );
 }
 
 =head2 subscribe

--- a/lib/Myriad/Service/Remote/RPC.pm
+++ b/lib/Myriad/Service/Remote/RPC.pm
@@ -1,0 +1,35 @@
+package Myriad::Service::Remote::RPC;
+
+# VERSION
+# AUTHORITY
+
+=encoding utf8
+
+=head1 NAME
+
+Myriad::Service::Remote::RPC - abstraction to access other services over the network.
+
+=head1 SYNOPSIS
+
+
+=head1 DESCRIPTION
+
+=cut
+
+use Myriad::Class;
+
+field $myriad : param;
+field $service : param;
+
+method DESTROY { }
+
+method AUTOLOAD (%args) {
+    my ($method) = our $AUTOLOAD =~ m{^.*::([^:]+)$};
+    return $myriad->rpc_client->call_rpc(
+        $service,
+        $method => %args
+    );
+}
+
+1;
+


### PR DESCRIPTION
Instead of:

```perl
 $srv->call_rpc(method_name => ...);
```

it looks more consistent with the rest of the code to be doing this:

```perl
 $srv->method_name(...)
```

and with introspection we'll be able to construct classes and provide "method not found" semantics later this way.