### PR TITLE
bugfix/subscription_error_on_exit

### DIFF
--- a/lib/Myriad/RPC/Client/Implementation/Redis.pm
+++ b/lib/Myriad/RPC/Client/Implementation/Redis.pm
@@ -61,7 +61,7 @@ async method start() {
         } catch ($e) {
             $log->warnf('failed to parse rpc response due %s', $e);
         }
-    })->completed;
+    });
 
     $started->done('started');
     $log->tracef('Started RPC client subscription on %s', $whoami);
@@ -109,7 +109,7 @@ async method call_rpc($service, $method, %args) {
 }
 
 async method stop {
-    $subscription->done();
+    $subscription->finish
 }
 
 method next_id {


### PR DESCRIPTION
Avoid calling ->done on a Ryu::Source, since that triggers a warning on exit.