### PR TITLE
bugfix/rpc_handling

### DIFF
--- a/lib/Myriad/RPC/Client/Implementation/Redis.pm
+++ b/lib/Myriad/RPC/Client/Implementation/Redis.pm
@@ -92,10 +92,14 @@ async method call_rpc($service, $method, %args) {
         await $redis->xadd($stream_name => '*', $request->as_hash->%*);
 
         # The subscription loop will parse the message for us
-        my $message = await Future->wait_any($self->loop->timeout_future(after => $timeout), $pending);
+        my $message = await Future->wait_any(
+            $self->loop->timeout_future(after => $timeout),
+            $pending
+        );
 
         return $message->response->{response};
     } catch ($e) {
+        $log->warnf('Failed on RPC call - %s', $e);
         if ($e =~ /Timeout/) {
             $e  = Myriad::Exception::RPC::Timeout->new(reason => 'deadline is due');
         } else {

--- a/lib/Myriad/RPC/Client/Implementation/Redis.pm
+++ b/lib/Myriad/RPC/Client/Implementation/Redis.pm
@@ -65,8 +65,7 @@ async method start() {
 
     $started->done('started');
     $log->tracef('Started RPC client subscription on %s', $whoami);
-
-    await $subscription;
+    return;
 }
 
 async method call_rpc($service, $method, %args) {

--- a/lib/Myriad/RPC/Implementation/Redis.pm
+++ b/lib/Myriad/RPC/Implementation/Redis.pm
@@ -141,7 +141,7 @@ async method stream_items_messages ($rpc, @items) {
     $processing->{$rpc->{stream}} = {};
 }
 
-async method listen () {
+method listen () {
     return $running //= (async sub {
         $log->tracef('Start listening to (%d) RPC streams', scalar($self->rpc_list->@*));
         await &fmap_void($self->$curry::curry(async method ($rpc) {

--- a/lib/Myriad/RPC/Implementation/Redis.pm
+++ b/lib/Myriad/RPC/Implementation/Redis.pm
@@ -143,8 +143,8 @@ async method stream_items_messages ($rpc, @items) {
 
 method listen () {
     return $running //= (async sub {
-        $log->tracef('Start listening to (%d) RPC streams', scalar($self->rpc_list->@*));
-        await &fmap_void($self->$curry::curry(async method ($rpc) {
+        $log->tracef('Start listening to (%d) RPC stream(s)', scalar($self->rpc_list->@*));
+        await &fmap_void($self->$curry::weak(async method ($rpc) {
             try {
                 await $self->create_group($rpc);
 

--- a/lib/Myriad/RPC/Implementation/Redis.pm
+++ b/lib/Myriad/RPC/Implementation/Redis.pm
@@ -87,7 +87,12 @@ async method stop () {
 async method create_group ($rpc) {
     unless ($rpc->{group}) {
         await $self->check_pending($rpc);
-        await $self->redis->create_group($rpc->{stream}, $self->group_name, '$', 1);
+        await $self->redis->create_group(
+            $rpc->{stream},
+            $self->group_name,
+            '0',
+            1
+        );
         $rpc->{group} = 1;
     }
 }

--- a/lib/Myriad/RPC/Implementation/Redis.pm
+++ b/lib/Myriad/RPC/Implementation/Redis.pm
@@ -113,8 +113,9 @@ async method check_pending ($rpc) {
 }
 
 async method stream_items_messages ($rpc, @items) {
+    ITEM:
     for my $item (@items) {
-        next unless $item->{data} || exists $processing->{$item->{id}};
+        next unless $item->{args} || exists $processing->{$item->{id}};
         my $data = {
             $item->{extra}->%*,
             data         => $item->{data},
@@ -128,7 +129,7 @@ async method stream_items_messages ($rpc, @items) {
                 $log->tracef('Skipping message %s because deadline is due - deadline: %s now: %s',
                     $message->transport_id, $message->deadline, time);
                 await $self->drop($rpc->{stream}, $item->{id});
-                next;
+                next ITEM;
             }
             $rpc->{sink}->emit($message);
         } catch ($error) {

--- a/lib/Myriad/RPC/Implementation/Redis.pm
+++ b/lib/Myriad/RPC/Implementation/Redis.pm
@@ -172,6 +172,7 @@ method listen () {
 async method reply ($service, $message) {
     my $stream = stream_name_from_service($service, $message->rpc);
     try {
+        $log->tracef('Reply to [%s] with %s', $message->who, $message->as_json);
         await $self->redis->publish($message->who, $message->as_json);
         await $self->redis->ack($stream, $self->group_name, $message->transport_id);
         $processing->{$stream}->{$message->transport_id}->done('published');

--- a/lib/Myriad/RPC/Implementation/Redis.pm
+++ b/lib/Myriad/RPC/Implementation/Redis.pm
@@ -164,7 +164,7 @@ method listen () {
                 $log->errorf('Failed on RPC listen - %s', $e);
                 die $e;
             }
-        }), foreach => [$self->rpc_list->@*], concurrent => scalar $self->rpc_list->@*);
+        }), foreach => [$self->rpc_list->@*], concurrent => 0 + $self->rpc_list->@*);
     })->();
 }
 

--- a/lib/Myriad/Storage.pm
+++ b/lib/Myriad/Storage.pm
@@ -69,7 +69,7 @@ sub new {
         require Myriad::Storage::Implementation::Memory;
         $STORAGE = Myriad::Storage::Implementation::Memory->new();
     } else {
-        Myriad::Exception::Storage::UnKnownTransport->throw();
+        Myriad::Exception::Storage::UnknownTransport->throw();
     }
     return $STORAGE;
 }

--- a/lib/Myriad/Transport/Redis.pm
+++ b/lib/Myriad/Transport/Redis.pm
@@ -340,7 +340,7 @@ async method cleanup (%args) {
                     MINID => '=',
                     $oldest,
                 );
-                $log->warnf(
+                $log->debugf(
                     'Approximate trimming failed to remove any items, resorting to slower exact trim method for stream %s, removed %d items total',
                     $stream,
                     $count

--- a/lib/Myriad/Transport/Redis.pm
+++ b/lib/Myriad/Transport/Redis.pm
@@ -278,6 +278,7 @@ async method read_from_stream (%args) {
                 stream => $self->remove_prefix($stream),
                 id     => $id,
                 data   => $data,
+                args   => $args->{args},
                 extra  => $args,
             }
         } $data->@*;
@@ -402,6 +403,7 @@ async method pending (%args) {
                     10,
                     $id
                 );
+                return unless $claim and $claim->@*;
                 $log->tracef('Claim is %s', $claim);
                 my $kv_pairs = $claim->[0]->[1] || [];
 
@@ -411,11 +413,12 @@ async method pending (%args) {
                     stream => $self->remove_prefix($stream),
                     id     => $id,
                     data   => $data,
+                    args   => $args->{args},
                     extra  => $args,
                 };
             }),
             foreach => $pending,
-            concurrent => scalar @$pending
+            concurrent => 0 + @$pending
         );
     } catch ($e) {
         $log->warnf('Could not read pending messages on stream: %s | error: %s', $stream, $e);


### PR DESCRIPTION
Addresses a few issues with RPC handling, some of which have been around for a while and others that were introduced as part of the compressed-data support from commit 11cc5a3431c9d7a7cb0f360b740ebe9c61ea0fa7.

This should also fix a memory leak in long-running processes which have a lot of RPC workers.