### PR TITLE
bugfix/test_default_memory_transport

### DIFF
--- a/lib/Myriad.pm
+++ b/lib/Myriad.pm
@@ -376,7 +376,7 @@ The L<Myriad::Transport::Memory> instance.
 
 method memory_transport () {
     unless ($memory_transport) {
-        $loop->add(
+        $self->loop->add(
             $memory_transport = Myriad::Transport::Memory->new
         );
     }
@@ -704,7 +704,7 @@ async method setup_metrics () {
     my $port = $config->metrics_port;
 
     try {
-        my $f = $loop->resolver->getaddrinfo(
+        my $f = $self->loop->resolver->getaddrinfo(
             host => $host->as_string,
             timeout => 10
         );
@@ -730,7 +730,8 @@ async method setup_metrics () {
         };
     }
 
-    my $code = sub {
+    my $loop = $self->loop;
+    my $code = $loop->$curry::weak(sub ($loop, @) {
         # Try to resolve the host first
         $loop->resolver->getaddrinfo(host => $host->as_string, timeout => 10)
         ->on_done(sub {
@@ -739,7 +740,7 @@ async method setup_metrics () {
             $log->errorf('metrics: unable to resolve host %s - %s', $host->as_string, shift);
             $host->set_string('127.0.0.1');
         })->retain();
-    };
+    });
 
     $adapter->subscribe($code);
     $host->subscribe($code);

--- a/lib/Myriad.pm
+++ b/lib/Myriad.pm
@@ -304,15 +304,11 @@ async method configure_from_argv (@args) {
     # method.
     my $method = 'service';
     while(@args) {
-        my $arg = shift @args;
-        if($commands->can($arg)) {
-            $method = $arg;
-            await $commands->$method(shift @args, @args);
-            last;
-        } else {
-            await $commands->$method($arg, @args);
-            last;
+        if($commands->can($args[0])) {
+            $method = shift @args;
         }
+        await $commands->$method(@args);
+        last;
     }
 
     $self->on_start(async method {

--- a/lib/Myriad/Commands.pm
+++ b/lib/Myriad/Commands.pm
@@ -79,8 +79,7 @@ async method service (@args) {
     # Ensure we have valid transports in place before we start
     for my $type (qw(storage subscription rpc)) {
         $log->tracef('Set up transport for [%s]', $type);
-        my $method = $myriad->config->${\"${type}_transport"}->as_string . '_transport';
-        my $instance = $myriad->$method;
+        my $instance = $myriad->transport($type);
         await $instance->start if $instance->can('start');
     }
 

--- a/lib/Myriad/Transport/Redis.pm
+++ b/lib/Myriad/Transport/Redis.pm
@@ -123,7 +123,7 @@ Number of items to allow per batch (pending / readgroup calls).
 method batch_count () { $batch_count }
 
 async method start {
-    $redis = await $self->redis;
+    $redis ||= await $self->redis;
     return;
 }
 

--- a/lib/Myriad/Transport/Redis.pm
+++ b/lib/Myriad/Transport/Redis.pm
@@ -124,11 +124,10 @@ Number of items to allow per batch (pending / readgroup calls).
 method batch_count () { $batch_count }
 
 async method start {
+    await $starting if $starting;
     return if $starting or $redis;
 
-    defer { $starting = 0 }
-    $starting = 1;
-    $redis = await $self->redis;
+    $redis = await $starting = $self->redis->on_ready(sub { undef $starting });
     return;
 }
 

--- a/lib/Myriad/Transport/Redis.pm
+++ b/lib/Myriad/Transport/Redis.pm
@@ -732,7 +732,7 @@ async method set_unless_exists ($key, $v, $ttl) {
     await $redis->set(
         $self->apply_prefix($key),
         $v,
-        qw(NX GET), 
+        qw(NX GET),
         defined $ttl ? ('PX', $ttl * 1000.0) : ()
     );
 }

--- a/lib/Myriad/Transport/Redis.pm
+++ b/lib/Myriad/Transport/Redis.pm
@@ -78,6 +78,7 @@ field $max_pool_count;
 field $clientside_cache_size;
 field $prefix;
 field $ryu;
+field $starting;
 
 field $cache_events;
 
@@ -123,7 +124,11 @@ Number of items to allow per batch (pending / readgroup calls).
 method batch_count () { $batch_count }
 
 async method start {
-    $redis ||= await $self->redis;
+    return if $starting or $redis;
+
+    defer { $starting = 0 }
+    $starting = 1;
+    $redis = await $self->redis;
     return;
 }
 

--- a/t/commands.t
+++ b/t/commands.t
@@ -27,6 +27,7 @@ BEGIN {
     Test::Myriad->add_service(name => "Test::Service::Mocked")->add_rpc('test_cmd', success => 1);
 }
 
+$ENV{MYRIAD_TRANSPORT} ||= 'memory';
 my $loop = IO::Async::Loop->new;
 testing_loop($loop);
 


### PR DESCRIPTION
Tests can't expect to have Redis or other transports available: we've had an issue in one of the tests that has been masked for a while, where it was trying to connect to Redis (but the test completed before it could throw an error).

Recent changes have exposed that failure, so this addresses the test transport and also ensures all transports are started so that we gain visibility on issues before we get too far into processing.