### PR TITLE
Support for unordered set methods

### DIFF
--- a/lib/Myriad/Role/Storage.pm
+++ b/lib/Myriad/Role/Storage.pm
@@ -45,7 +45,24 @@ a concrete implementation - instead, see classes such as:
 
 =cut
 
-our @WRITE_METHODS = qw(set getset getdel incr push unshift pop shift hash_set hash_add orderedset_add orderedset_remove_member orderedset_remove_byscore del unlink set_unless_exists);
+our @WRITE_METHODS = qw(
+    set
+    getset
+    getdel
+    incr
+    push
+    unshift
+    pop
+    shift
+    hash_set
+    hash_add
+    orderedset_add
+    orderedset_remove_member
+    orderedset_remove_byscore
+    del
+    unlink
+    set_unless_exists
+);
 
 =head2 set
 
@@ -264,7 +281,20 @@ method set_unless_exists;
 
 =cut
 
-our @READ_METHODS = qw(get observe watch_keyspace hash_get hash_keys hash_values hash_exists hash_count hash_as_list orderedset_member_count orderedset_members when_key_changed);
+our @READ_METHODS = qw(
+    get
+    observe
+    watch_keyspace
+    hash_get
+    hash_keys
+    hash_values
+    hash_exists
+    hash_count
+    hash_as_list
+    orderedset_member_count
+    orderedset_members
+    when_key_changed
+);
 
 =head2 get
 

--- a/lib/Myriad/Role/Storage.pm
+++ b/lib/Myriad/Role/Storage.pm
@@ -59,6 +59,9 @@ our @WRITE_METHODS = qw(
     orderedset_add
     orderedset_remove_member
     orderedset_remove_byscore
+    unorderedset_add
+    unorderedset_remove
+    unorderedset_replace
     del
     unlink
     set_unless_exists
@@ -233,7 +236,7 @@ Returns a L<Future>.
 
 method orderedset_add;
 
-=head2 orderedset_remove_memeber
+=head2 orderedset_remove_member
 
 Removes a member from an orderedset structure
 Takes the following parameters:
@@ -273,6 +276,63 @@ Returns a L<Future>.
 
 method orderedset_remove_byscore;
 
+=head2 unorderedset_add
+
+Adds members to a set.
+Takes the following parameters:
+
+=over 4
+
+=item * C<< $k >> - the relative key in storage
+
+=item * C<< $members >> - an arrayref holding zero or more members to add
+
+=back
+
+Returns a L<Future>.
+
+=cut
+
+method unorderedset_add;
+
+=head2 unorderedset_remove
+
+Removes members from a set.
+Takes the following parameters:
+
+=over 4
+
+=item * C<< $k >> - the relative key in storage
+
+=item * C<< $members >> - an arrayref holding zero or more members to remove
+
+=back
+
+Returns a L<Future>.
+
+=cut
+
+method unorderedset_remove;
+
+=head2 unorderedset_replace
+
+Atomically replace all members in a set.
+Takes the following parameters:
+
+=over 4
+
+=item * C<< $k >> - the relative key in storage
+
+=item * C<< $members >> - an arrayref holding zero or more members to form the new set
+
+=back
+
+Returns a L<Future>.
+
+=cut
+
+method unorderedset_replace;
+
 method del;
 method unlink;
 method set_unless_exists;
@@ -293,6 +353,9 @@ our @READ_METHODS = qw(
     hash_as_list
     orderedset_member_count
     orderedset_members
+    unorderedset_is_member
+    unorderedset_member_count
+    unorderedset_members
     when_key_changed
 );
 
@@ -460,6 +523,60 @@ Returns a L<Future>.
 =cut
 
 method orderedset_members;
+
+=head2 unorderedset_is_member
+
+Returns true if the given key is a member in the set.
+Takes the following parameters:
+
+=over 4
+
+=item * C<< $k >> - the relative key in storage
+
+=item * C<< $value >> - the value to check for presence in the set
+
+=back
+
+Returns a L<Future>.
+
+=cut
+
+method unorderedset_is_member;
+
+=head2 unorderedset_member_count
+
+Returns the count of all members.
+
+Takes the following parameters:
+
+=over 4
+
+=item * C<< $k >> - the relative key in storage
+
+=back
+
+Returns a L<Future>.
+
+=cut
+
+method unorderedset_member_count;
+
+=head2 unorderedset_members
+
+Returns a list of all members in the set.
+Takes the following parameters:
+
+=over 4
+
+=item * C<< $k >> - the relative key in storage
+
+=back
+
+Returns a L<Future>.
+
+=cut
+
+method unorderedset_members;
 
 method when_key_changed;
 

--- a/lib/Myriad/Storage/Implementation/Redis.pm
+++ b/lib/Myriad/Storage/Implementation/Redis.pm
@@ -517,6 +517,80 @@ async method orderedset_remove_byscore ($k, $min, $max) {
     await $redis->zremrangebyscore($self->apply_prefix($k), $min => $max);
 }
 
+=head2 unorderedset_add
+
+Takes the following parameters:
+
+=over 4
+
+=item * C<< $k >> - the relative key in storage
+
+=item * C<< $m >> - the scalar member value
+
+=back
+
+Note that references are B<not> supported - attempts to write an arrayref, hashref
+or object will fail.
+
+Redis sorted sets data structure family.
+add a scored member value to a storage key
+
+Returns a L<Future> which will resolve on completion.
+
+=cut
+
+async method unorderedset_add ($k, $m) {
+    $m = [ $m ] unless ref($m) eq 'ARRAY';
+    die 'set member values cannot be a reference for key:' . $k . ' - ' . ref($_) for grep { ref } $m->@*;
+    await $redis->sadd($self->apply_prefix($k), $m->@*);
+}
+
+=head2 unorderedset_remove
+
+Takes the following parameters:
+
+=over 4
+
+=item * C<< $k >> - the relative key in storage
+
+=item * C<< $m >> - the scalar member value
+
+=back
+
+Returns a L<Future> which will resolve on completion.
+
+=cut
+
+async method unorderedset_remove ($k, $m) {
+    $m = [ $m ] unless ref($m) eq 'ARRAY';
+    await $redis->srem($self->apply_prefix($k), $m->@*);
+}
+
+=head2 unorderedset_replace
+
+Takes the following parameters:
+
+=over 4
+
+=item * C<< $k >> - the relative key in storage
+
+=item * C<< $m >> - the scalar member value
+
+=back
+
+Returns a L<Future> which will resolve on completion.
+
+=cut
+
+async method unorderedset_replace ($k, $m) {
+    $m = [ $m ] unless ref($m) eq 'ARRAY';
+    my $prefixed = $self->apply_prefix($k);
+    await $redis->multi(sub ($redis) {
+        $redis->unlink($prefixed);
+        $redis->sadd($prefixed, $m->@*);
+    });
+}
+
 async method unlink (@keys) {
     await $redis->unlink(map { $self->apply_prefix($_) } @keys);
     return $self;
@@ -577,6 +651,46 @@ Returns a L<Future> which will resolve on completion.
 
 async method orderedset_members ($k, $min = '-inf', $max = '+inf', $with_score = 0) {
     await $redis->zrange($self->apply_prefix($k), $min => $max, 'BYSCORE', ($with_score ? 'WITHSCORES' : ()));
+}
+
+=head2 unorderedset_member_count
+
+Takes the following parameters:
+
+=over 4
+
+=item * C<< $k >> - the relative key in storage
+
+=back
+
+Returns a L<Future> which will resolve on completion.
+
+=cut
+
+async method unorderedset_member_count ($k) {
+    await $redis->scard($self->apply_prefix($k));
+}
+
+=head2 unorderedset_members
+
+Takes the following parameters:
+
+=over 4
+
+=item * C<< $k >> - the relative key in storage
+
+=back
+
+Returns a L<Future> which will resolve on completion.
+
+=cut
+
+async method unorderedset_members ($k) {
+    await $redis->smembers($self->apply_prefix($k));
+}
+
+async method unorderedset_is_member ($k, $m) {
+    await $redis->sismember($self->apply_prefix($k), $m);
 }
 
 1;


### PR DESCRIPTION
To complement the ordered set handling, we'd want support for unordered sets. This adds those to the memory and Redis implementations with an `unorderedset_` prefix, makes them slightly verbose to type but hopefully clear enough.

In Redis, these are backed by `SADD`, `SREM` etc., see https://redis.io/docs/latest/commands/?group=set for more details.