### PR TITLE
Support for passing hashref to ->hash_set

### DIFF
--- a/lib/Myriad/Storage/Implementation/Memory.pm
+++ b/lib/Myriad/Storage/Implementation/Memory.pm
@@ -273,13 +273,15 @@ Returns a L<Future> which will resolve to .
 
 =cut
 
-async method hash_set : Defer ($k, %args) {
-    for my $hash_key (sort keys %args) {
-        my $v = $args{$hash_key};
+async method hash_set : Defer ($k, $hash_key, $v //= undef) {
+    if(ref $hash_key eq 'HASH') {
+        @{$data{$k}}{keys $hash_key->%*} = values $hash_key->%*;
+        return 0 + keys $hash_key->%*;
+    } else {
         die 'value cannot be a reference for ' . $k . ' hash key ' . $hash_key . ' - ' . ref($v) if ref $v;
+        $data{$k}{$hash_key} = $v;
+        return 1;
     }
-    @{$data{$k}}{keys %args} = values %args;
-    return 0 + keys %args;
 }
 
 =head2 hash_get

--- a/lib/Myriad/Storage/Implementation/Redis.pm
+++ b/lib/Myriad/Storage/Implementation/Redis.pm
@@ -305,9 +305,13 @@ Returns a L<Future> which will resolve to .
 
 =cut
 
-async method hash_set ($k, $hash_key, $v) {
-    die 'value cannot be a reference for ' . $k . ' - ' . ref($v) if ref $v;
-    await $redis->hset($self->apply_prefix($k), $hash_key, $v);
+async method hash_set ($k, $hash_key, $v //= undef) {
+    if(ref $hash_key eq 'HASH') {
+        await $redis->hmset($self->apply_prefix($k), $hash_key->%*);
+    } else {
+        die 'value cannot be a reference for ' . $k . ' - ' . ref($v) if ref $v;
+        await $redis->hset($self->apply_prefix($k), $hash_key, $v);
+    }
 }
 
 =head2 hash_get


### PR DESCRIPTION
Redis and other backends tend to support multiple key/value pairs, which is more efficient than setting one value at a time in a larger hash structure. We add support for this by allowing either single `key => value`, or a hashref (with no value).