### PR TITLE
Support for `list_count` storage method

### DIFF
--- a/lib/Myriad/Role/Storage.pm
+++ b/lib/Myriad/Role/Storage.pm
@@ -351,6 +351,7 @@ our @READ_METHODS = qw(
     hash_exists
     hash_count
     hash_as_list
+    list_count
     list_range
     orderedset_member_count
     orderedset_members
@@ -482,6 +483,22 @@ suitable for assigning to a hash.
 =cut
 
 method hash_as_list;
+
+=head2 list_count
+
+Takes the following parameters:
+
+=over 4
+
+=item * key
+
+=back
+
+Returns a L<Future> which will resolve to the integer count of values currently in the list.
+
+=cut
+
+method list_count;
 
 =head2 list_range
 

--- a/lib/Myriad/Storage/Implementation/Memory.pm
+++ b/lib/Myriad/Storage/Implementation/Memory.pm
@@ -413,6 +413,10 @@ async method hash_as_list : Defer ($k) {
     return $data{$k}->%*;
 }
 
+async method list_count : Defer ($k) {
+    return 0 + $data{$k}->@*;
+}
+
 async method list_range : Defer ($k, $start = 0, $end = -1) {
     my $len = 0 + $data{$k}->@*
         or return [ ];

--- a/lib/Myriad/Storage/Implementation/Redis.pm
+++ b/lib/Myriad/Storage/Implementation/Redis.pm
@@ -215,6 +215,10 @@ async method watch_keyspace ($keyspace) {
     });
 }
 
+async method list_count ($k) {
+    await $redis->llen($self->apply_prefix($k));
+}
+
 async method list_range ($k, $start = 0, $end = -1) {
     await $redis->lrange($self->apply_prefix($k), $start, $end);
 }


### PR DESCRIPTION
This adds a method for returning the current number of items in a list in storage.