### PR TITLE
Pin XS::Parse::Keyword to working version, due to 0.43 breakage

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -4,7 +4,7 @@ requires 'mro';
 requires 'indirect';
 requires 'multidimensional';
 requires 'bareword::filehandles';
-requires 'XS::Parse::Keyword', '>= 0.42';
+requires 'XS::Parse::Keyword', '== 0.42';
 requires 'Syntax::Keyword::Dynamically', '>= 0.13';
 requires 'Syntax::Keyword::Try', '>= 0.29';
 requires 'Syntax::Keyword::Defer', '>= 0.10';


### PR DESCRIPTION
The header files can no longer be found by dependent modules, e.g. Syntax::Keyword::Match, due to this change:

```
 * Use `File::ShareDir` for storing .h include files, rather than
   storing the contents in the `__DATA__` section of the build helpers
```

Pinning to a working version for now.

Symptoms are errors such as these in `cpanm` installation logs:

```
lib/Syntax/Keyword/Match.xs:18:10: fatal error: hax/perl-backcompat.c.inc: No such file or directory
   18 | #include "hax/perl-backcompat.c.inc"
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
```