### PR TITLE
Backward compatibility for perl 5.36.0

### DIFF
--- a/lib/Myriad/Class.pm
+++ b/lib/Myriad/Class.pm
@@ -245,7 +245,6 @@ sub import {
         current_sub
         evalbytes
         fc
-        module_true
         postderef_qq
         state
         unicode_eval

--- a/lib/Myriad/Storage/Implementation/Memory.pm
+++ b/lib/Myriad/Storage/Implementation/Memory.pm
@@ -273,7 +273,7 @@ Returns a L<Future> which will resolve to .
 
 =cut
 
-async method hash_set : Defer ($k, $hash_key, $v //= undef) {
+async method hash_set : Defer ($k, $hash_key, $v = undef) {
     if(ref $hash_key eq 'HASH') {
         @{$data{$k}}{keys $hash_key->%*} = values $hash_key->%*;
         return 0 + keys $hash_key->%*;

--- a/lib/Myriad/Storage/Implementation/Redis.pm
+++ b/lib/Myriad/Storage/Implementation/Redis.pm
@@ -313,7 +313,7 @@ Returns a L<Future> which will resolve to .
 
 =cut
 
-async method hash_set ($k, $hash_key, $v //= undef) {
+async method hash_set ($k, $hash_key, $v = undef) {
     if(ref $hash_key eq 'HASH') {
         await $redis->hmset($self->apply_prefix($k), $hash_key->%*);
     } else {


### PR DESCRIPTION
Support signature format for earlier Perl versions which did not yet have `//=`. We only want to provide a default here when there's no parameter supplied, technically `//= undef` doesn't make much sense anyway.