### PR TITLE
Ensure our RPC/subscription group exists before we check for pending messages

### DIFF
--- a/lib/Myriad/RPC/Implementation/Redis.pm
+++ b/lib/Myriad/RPC/Implementation/Redis.pm
@@ -91,7 +91,6 @@ async method stop () {
 
 async method create_group ($rpc) {
     unless ($rpc->{group}) {
-        await $self->check_pending($rpc);
         await $self->redis->create_group(
             $rpc->{stream},
             $self->group_name,
@@ -104,6 +103,7 @@ async method create_group ($rpc) {
             $method,
             $self->group_name,
         );
+        await $self->check_pending($rpc);
         $rpc->{group} = 1;
     }
 }

--- a/lib/Myriad/Transport/Redis.pm
+++ b/lib/Myriad/Transport/Redis.pm
@@ -425,7 +425,7 @@ async method pending (%args) {
             concurrent => 0 + @$pending
         );
     } catch ($e) {
-        $log->warnf('Could not read pending messages on stream: %s | error: %s', $stream, $e);
+        $log->warnf('Could not read pending messages on stream: %s | error: %s', $stream, $e) unless $e =~ /^NOGROUP/;
     }
     $self->return_instance_to_pool($instance) if $instance;
     undef $instance;


### PR DESCRIPTION
When deploying a new service, there's a check for pending messages on all RPC queues - looking for items that have been started but not acknowledged by the previous consumer (i.e. process died before they completed).

Since those streams don't exist yet, this was displaying a warning:

> Could not read pending messages on stream: `myriad.service.example.service.rpc/warning_sample` | error: NOGROUP No such key '`myriad.service.example.service.rpc/warning_sample`' or consumer group 'processors' at .../Net/Async/Redis/Cluster.pm line 691.

Although harmless, this happens frequently enough to be distracting, and technically shouldn't happen: we should always create our streams first before trying to do anything with them. This change applies the pending check after stream creation.