### PR TITLE
Fix RPC pending queue error handling

### DIFF
--- a/lib/Myriad/RPC/Client/Implementation/Memory.pm
+++ b/lib/Myriad/RPC/Client/Implementation/Memory.pm
@@ -93,7 +93,7 @@ async method call_rpc ($service, $method, %args) {
         if ($e =~ /Timeout/) {
             $e  = Myriad::Exception::RPC::Timeout->new(reason => 'deadline is due');
         } else {
-            $e = Myriad::Exception::InternalError->new(reason => $e) unless blessed $e && $e->does('Myriad::Exception');
+            $e = Myriad::Exception::InternalError->new(reason => $e) unless blessed $e && $e->DOES('Myriad::Exception');
         }
         $pending->fail($e);
         delete $pending_requests->{$message_id};

--- a/lib/Myriad/RPC/Client/Implementation/Redis.pm
+++ b/lib/Myriad/RPC/Client/Implementation/Redis.pm
@@ -103,7 +103,7 @@ async method call_rpc($service, $method, %args) {
         if ($e =~ /Timeout/) {
             $e  = Myriad::Exception::RPC::Timeout->new(reason => 'deadline is due');
         } else {
-            $e = Myriad::Exception::InternalError->new(reason => $e) unless blessed $e && $e->does('Myriad::Exception');
+            $e = Myriad::Exception::InternalError->new(reason => $e) unless blessed $e && $e->DOES('Myriad::Exception');
         }
         $pending->fail($e);
         delete $pending_requests->{$message_id};

--- a/lib/Myriad/RPC/Implementation/Redis.pm
+++ b/lib/Myriad/RPC/Implementation/Redis.pm
@@ -90,22 +90,22 @@ async method stop () {
 }
 
 async method create_group ($rpc) {
-    unless ($rpc->{group}) {
-        await $self->redis->create_group(
-            $rpc->{stream},
-            $self->group_name,
-            '0',
-            1
-        );
-        my ($service, $method) = service_from_stream_name($rpc->{stream});
-        await $self->redis->hset(
-            "rpc.group.{$service}",
-            $method,
-            $self->group_name,
-        );
-        await $self->check_pending($rpc);
-        $rpc->{group} = 1;
-    }
+    return if $rpc->{group};
+
+    await $self->redis->create_group(
+        $rpc->{stream},
+        $self->group_name,
+        '0',
+        1
+    );
+    my ($service, $method) = service_from_stream_name($rpc->{stream});
+    await $self->redis->hset(
+        "rpc.group.{$service}",
+        $method,
+        $self->group_name,
+    );
+    await $self->check_pending($rpc);
+    $rpc->{group} = 1;
 }
 
 async method check_pending ($rpc) {
@@ -126,13 +126,15 @@ async method check_pending ($rpc) {
 async method stream_items_messages ($rpc, @items) {
     ITEM:
     for my $item (@items) {
-        next unless $item->{args} || exists $processing->{$item->{id}};
+        next ITEM unless $item->{args} || exists $processing->{$item->{id}};
         my $data = {
             $item->{extra}->%*,
             data         => $item->{data},
             transport_id => $item->{id},
         };
-        $processing->{$rpc->{stream}}->{$item->{id}} = $self->loop->new_future(label => "rpc::response::$rpc->{stream}::$item->{id}");
+        $processing->{$rpc->{stream}}->{$item->{id}} = $self->loop->new_future(
+            label => "rpc::response::$rpc->{stream}::$item->{id}"
+        );
         try {
             my $message = Myriad::RPC::Message::from_hash($data->%*);
             $log->tracef('Passing message: %s to: %s', $message, $rpc->{sink}->label);
@@ -207,6 +209,7 @@ async method drop ($stream, $id) {
     $log->tracef("Going to drop message ID: %s on stream: %s", $id, $stream);
     await $self->redis->ack($stream, $self->group_name, $id);
     $processing->{$stream}->{$id}->done('published');
+    return;
 }
 
 async method has_pending_requests ($service) {

--- a/lib/Myriad/RPC/Implementation/Redis.pm
+++ b/lib/Myriad/RPC/Implementation/Redis.pm
@@ -104,13 +104,14 @@ async method create_group ($rpc) {
         $method,
         $self->group_name,
     );
-    await $self->check_pending($rpc);
     $rpc->{group} = 1;
+    await $self->check_pending($rpc);
+    return;
 }
 
 async method check_pending ($rpc) {
     my $done = 0;
-    while ( !$done && !$rpc->{group}) {
+    until ( $done ) {
         my @items = await $self->redis->pending(
             stream => $rpc->{stream},
             group  => $self->group_name,

--- a/lib/Myriad/Service/Implementation.pm
+++ b/lib/Myriad/Service/Implementation.pm
@@ -372,7 +372,7 @@ async method load () {
                 } catch ($e) {
                     $e = Myriad::Exception::InternalError->new(
                         reason => $e
-                    ) unless blessed($e) and $e->does('Myriad::Exception');
+                    ) unless blessed($e) and $e->DOES('Myriad::Exception');
                     if(USE_OPENTELEMETRY) {
                         $span->record_exception($e);
                         $span->set_status(

--- a/lib/Myriad/Subscription/Implementation/Memory.pm
+++ b/lib/Myriad/Subscription/Implementation/Memory.pm
@@ -121,7 +121,7 @@ async method start {
                 } catch ($e) {
                     $e = Myriad::Exception::InternalError->new(
                         reason => $e
-                    ) unless blessed($e) and $e->does('Myriad::Exception');
+                    ) unless blessed($e) and $e->DOES('Myriad::Exception');
                     $log->errorf('Failed to process event %s - %s', $event_id, $e);
                     $span->record_exception($e);
                     $span->set_status(

--- a/lib/Myriad/Subscription/Implementation/Redis.pm
+++ b/lib/Myriad/Subscription/Implementation/Redis.pm
@@ -235,7 +235,7 @@ async method receive_items {
                     } catch($e) {
                         $e = Myriad::Exception::InternalError->new(
                             reason => $e
-                        ) unless blessed($e) and $e->does('Myriad::Exception');
+                        ) unless blessed($e) and $e->DOES('Myriad::Exception');
                         $log->errorf(
                             'An error happened while decoding event data for stream %s message: %s, error: %s',
                             $stream,


### PR DESCRIPTION
Applies some improvements to our initial pending-message-claim sequence, and how we deal with exceptions thrown by various related paths.