### PR TITLE
Only enable OpenTelemetry when explicitly requested

### DIFF
--- a/lib/Myriad/Service/Implementation.pm
+++ b/lib/Myriad/Service/Implementation.pm
@@ -23,14 +23,19 @@ use Myriad::Util::UUID;
 
 use Myriad::Service::Attributes;
 
-use OpenTelemetry::Context;
-use OpenTelemetry::Trace;
-use OpenTelemetry::Constants qw( SPAN_STATUS_ERROR SPAN_STATUS_OK );
-
 # Only defer up to this many seconds between batch iterations
 use constant MAX_EXPONENTIAL_BACKOFF => 2;
 
-use constant USE_OPENTELEMETRY => 0;
+use constant USE_OPENTELEMETRY => $ENV{USE_OPENTELEMETRY} || 0;
+
+BEGIN {
+    if(USE_OPENTELEMETRY) {
+        require OpenTelemetry::Context;
+        require OpenTelemetry::Trace;
+        require OpenTelemetry::Constants;
+        OpenTelemetry::Constants->import(qw( SPAN_STATUS_ERROR SPAN_STATUS_OK ));
+    }
+}
 
 sub MODIFY_CODE_ATTRIBUTES {
     my ($class, $code, @attrs) = @_;

--- a/lib/Myriad/Subscription/Implementation/Memory.pm
+++ b/lib/Myriad/Subscription/Implementation/Memory.pm
@@ -5,9 +5,16 @@ use Myriad::Class ':v2', extends => qw(IO::Async::Notifier), does => [
     'Myriad::Util::Defer'
 ];
 
-use OpenTelemetry::Context;
-use OpenTelemetry::Trace;
-use OpenTelemetry::Constants qw( SPAN_STATUS_ERROR SPAN_STATUS_OK );
+use constant USE_OPENTELEMETRY => $ENV{USE_OPENTELEMETRY};
+
+BEGIN {
+    if(USE_OPENTELEMETRY) {
+        require OpenTelemetry::Context;
+        require OpenTelemetry::Trace;
+        require OpenTelemetry::Constants;
+        OpenTelemetry::Constants->import(qw( SPAN_STATUS_ERROR SPAN_STATUS_OK ));
+    }
+}
 
 # VERSION
 # AUTHORITY
@@ -96,37 +103,55 @@ async method start {
                 $subscription->{group_name},
                 'consumer'
             );
-            for my $event_id (sort keys $messages->%*) {
-                my $span = $tracer->create_span(
-                    parent => OpenTelemetry::Context->current,
-                    name   => $subscription->{channel},
-                    attributes => {
-                        group => $subscription->{group_name},
-                    },
-                );
-                try {
-                    my $context = OpenTelemetry::Trace->context_with_span($span);
-                    dynamically OpenTelemetry::Context->current = $context;
+            if(USE_OPENTELEMETRY) {
+                for my $event_id (sort keys $messages->%*) {
+                    my $span = $tracer->create_span(
+                        parent => OpenTelemetry::Context->current,
+                        name   => $subscription->{channel},
+                        attributes => {
+                            group => $subscription->{group_name},
+                        },
+                    );
+                    try {
+                        my $context = OpenTelemetry::Trace->context_with_span($span);
+                        dynamically OpenTelemetry::Context->current = $context;
 
-                    $subscription->{sink}->emit($messages->{$event_id});
-                    await $transport->ack_message(
-                        $subscription->{channel},
-                        $subscription->{group_name},
-                        $event_id
-                    );
+                        $subscription->{sink}->emit($messages->{$event_id});
+                        await $transport->ack_message(
+                            $subscription->{channel},
+                            $subscription->{group_name},
+                            $event_id
+                        );
 
-                    $span->set_status(
-                        SPAN_STATUS_OK
-                    );
-                } catch ($e) {
-                    $e = Myriad::Exception::InternalError->new(
-                        reason => $e
-                    ) unless blessed($e) and $e->DOES('Myriad::Exception');
-                    $log->errorf('Failed to process event %s - %s', $event_id, $e);
-                    $span->record_exception($e);
-                    $span->set_status(
-                        SPAN_STATUS_ERROR, $e
-                    );
+                        $span->set_status(
+                            SPAN_STATUS_OK
+                        );
+                    } catch ($e) {
+                        $e = Myriad::Exception::InternalError->new(
+                            reason => $e
+                        ) unless blessed($e) and $e->DOES('Myriad::Exception');
+                        $log->errorf('Failed to process event %s - %s', $event_id, $e);
+                        $span->record_exception($e);
+                        $span->set_status(
+                            SPAN_STATUS_ERROR, $e
+                        );
+                    }
+                }
+            } else {
+                for my $event_id (sort keys $messages->%*) {
+                    try {
+                        $subscription->{sink}->emit($messages->{$event_id});
+                        await $transport->ack_message(
+                            $subscription->{channel},
+                            $subscription->{group_name},
+                            $event_id
+                        );
+                    } catch ($e) {
+                        $e = Myriad::Exception::InternalError->new(
+                            reason => $e
+                        ) unless blessed($e) and $e->DOES('Myriad::Exception');
+                        $log->errorf('Failed to process event %s - %s', $event_id, $e);
+                    }
                 }
             }
 

--- a/lib/Myriad/Subscription/Implementation/Redis.pm
+++ b/lib/Myriad/Subscription/Implementation/Redis.pm
@@ -9,13 +9,19 @@ use Myriad::Class ':v2', extends => qw(IO::Async::Notifier), does => [
 
 use Myriad::Util::UUID;
 use Compress::Zstd ();
-use OpenTelemetry::Context;
-use OpenTelemetry::Trace;
-use OpenTelemetry::Constants qw( SPAN_STATUS_ERROR SPAN_STATUS_OK );
 
 use constant MAX_ALLOWED_STREAM_LENGTH => 10_000;
 
-use constant USE_OPENTELEMETRY => 0;
+use constant USE_OPENTELEMETRY => $ENV{USE_OPENTELEMETRY};
+
+BEGIN {
+    if(USE_OPENTELEMETRY) {
+        require OpenTelemetry::Context;
+        require OpenTelemetry::Trace;
+        require OpenTelemetry::Constants;
+        OpenTelemetry::Constants->import(qw( SPAN_STATUS_ERROR SPAN_STATUS_OK ));
+    }
+}
 
 field $redis;
 


### PR DESCRIPTION
Avoid loading or calling OpenTelemetry unless explicitly enabled, e.g. via

```
USE_OPENTELEMETRY=1 myriad.pl ...
```

This is due to stability problems relating to `dynamically` and cancellation/exception handling: especially on recent versions of Perl, we're seeing various memory corruption issues. Since this is supposed to be an opt-in feature, due to performance hit and that it's not useful without the OpenTelemetry endpoint and infrastructure available, disabling by default was the intended direction anyway.

Symptoms include:

```
Attempt to free unreferenced scalar: SV 0x5603c40210f8 at /opt/perl-5.40.0/lib/site_perl/5.40.0/OpenTelemetry/Context.pm line 9.
```

and segmentation faults.

This change attempts to bypass OpenTelemetry (including module load) unless the `USE_OPENTELEMETRY` environment variable is set. Previously, we'd be creating contexts and spans in some places regardless of whether it was enabled.