### PR TITLE
Only enable the specific Object::Pad experimental features we need

### DIFF
--- a/lib/Myriad/Exception/Builder.pm
+++ b/lib/Myriad/Exception/Builder.pm
@@ -18,7 +18,7 @@ See L<Myriad::Exception> for the rôle that defines the exception API.
 =cut
 
 # We deliberately *don't* want class/method keywords, but *do* want MOP
-use Object::Pad qw(:experimental);
+use Object::Pad qw(:experimental(mop));
 
 use Myriad::Exception;
 use Myriad::Exception::Base;

--- a/lib/Test/Myriad.pm
+++ b/lib/Test/Myriad.pm
@@ -10,7 +10,7 @@ use IO::Async::Loop;
 use Future::Utils qw(fmap0);
 use Future::AsyncAwait;
 use Check::UnitCheck;
-use Object::Pad qw(:experimental);
+use Object::Pad qw(:experimental(mop));
 
 use Myriad;
 use Myriad::Service::Implementation;

--- a/t/define_role.t
+++ b/t/define_role.t
@@ -8,7 +8,7 @@ BEGIN {
 }
 
 use Test::More;
-use Object::Pad qw(:experimental);
+use Object::Pad qw(:experimental(mop));
 
 subtest 'create a rôle' => sub {
     ok(eval <<'EOF', 'create rôle')

--- a/t/role.t
+++ b/t/role.t
@@ -12,7 +12,7 @@ BEGIN {
 use Test::More;
 use Test::Fatal;
 use Test::Deep;
-use Object::Pad qw(:experimental);
+use Object::Pad qw(:experimental(mop));
 
 is(exception {
     eval <<'EOS' or die $@;


### PR DESCRIPTION
Turning on _everything_ considered harmful, see Github issue #334 for an example of this.