### PR TITLE
Test/data checks exception format

### DIFF
--- a/lib/Myriad/Class.pm
+++ b/lib/Myriad/Class.pm
@@ -396,7 +396,7 @@ sub import {
     }
 
     if(my $class = $args{class} // $pkg) {
-        Object::Pad->import_into($pkg, ":experimental(init_expr mop custom_field_attr adjust_params)");
+        Object::Pad->import_into($pkg, ":experimental(init_expr mop custom_field_attr)");
 
         my $method = 'begin_' . ($args{type} || 'class');
         Module::Load::load($args{extends}) if $args{extends};

--- a/t/RPC/full-cycle.t
+++ b/t/RPC/full-cycle.t
@@ -8,7 +8,7 @@ use Log::Any::Adapter qw(TAP);
 
 use Future;
 use Future::AsyncAwait;
-use Object::Pad qw(:experimental);
+use Object::Pad;
 
 my ($ping_service, $pong_service);
 

--- a/t/RPC/overflow-protection.t
+++ b/t/RPC/overflow-protection.t
@@ -12,7 +12,7 @@ use Myriad::Transport::Memory;
 use Myriad::Transport::Redis;
 use Myriad::RPC::Message;
 use Sys::Hostname qw(hostname);
-use Object::Pad qw(:experimental);
+use Object::Pad qw(:experimental(mop));
 
 use Myriad;
 

--- a/t/RPC/pending-requests.t
+++ b/t/RPC/pending-requests.t
@@ -12,7 +12,7 @@ use Myriad::Transport::Memory;
 use Myriad::Transport::Redis;
 use Myriad::RPC::Message;
 use Sys::Hostname qw(hostname);
-use Object::Pad qw(:experimental);
+use Object::Pad qw(:experimental(mop));
 
 use Myriad;
 

--- a/t/commands.t
+++ b/t/commands.t
@@ -7,7 +7,7 @@ use Test::MockObject;
 use Test::Fatal;
 use Test::Deep;
 
-use Object::Pad qw(:experimental);
+use Object::Pad qw(:experimental(mop));
 use Log::Any::Adapter qw(TAP);
 
 use Future::AsyncAwait;

--- a/t/myriad.t
+++ b/t/myriad.t
@@ -10,7 +10,7 @@ use Test::MockObject;
 use Future::AsyncAwait;
 use IO::Async::Test;
 
-use Object::Pad qw(:experimental);
+use Object::Pad qw(:experimental(mop));
 
 sub loop_notifiers {
     my $loop = shift;

--- a/t/registry.t
+++ b/t/registry.t
@@ -11,7 +11,7 @@ use IO::Async::Test;
 use Future::AsyncAwait;
 # Needed to set Testing::Service method names without fully defining service as Myriad::Service
 use Sub::Util qw(subname set_subname);
-use Object::Pad qw(:experimental);
+use Object::Pad qw(:experimental(mop));
 
 use Myriad;
 use Myriad::Registry;

--- a/t/syntax.t
+++ b/t/syntax.t
@@ -167,10 +167,10 @@ subtest 'Myriad::Class :v2' => sub {
     }, undef, 'can check numeric >= 5');
     like(exception {
         $obj->checked(-3)
-    }, qr/\Qsatisfying :Checked(NumGE(5))/, 'numeric check fails on number out of range');
+    }, qr/\Qsatisfying NumGE(5)/, 'numeric check fails on number out of range');
     like(exception {
         $obj->checked('xx')
-    }, qr/\Qsatisfying :Checked(NumGE(5))/, 'numeric check fails on invalid number');
+    }, qr/\Qsatisfying NumGE(5)/, 'numeric check fails on invalid number');
     done_testing;
 };
 done_testing;


### PR DESCRIPTION
Latest Data::Checks uses a different format in the exceptions when failing validation.

There are also a few other test file fixes to resolve warnings showing up with current CPAN versions, and to drop an obsolete experimental feature (parameters for `ADJUST` blocks, already enabled by default) in Object::Pad.

No functional change expected.