### PR TITLE
Support `key` parameter in `$api->mutex`

### DIFF
--- a/lib/Myriad/API.pm
+++ b/lib/Myriad/API.pm
@@ -95,12 +95,14 @@ method config ($key) {
 
 async method mutex (@args) {
     my ($code) = extract_by { ref($_) eq 'CODE' } @args;
+    # `name` is used for a shared mutex across services
     my $name = @args % 2 ? shift(@args) : $service_name;
     my %args = @args;
-    $log->infof('Service = %s', "$service");
+    # `key` is used for a suffix for a specific service
+    my $suffix = delete($args{key}) // '';
     my $mutex = Myriad::Mutex->new(
         %args,
-        key     => $name,
+        key     => $name . (length($suffix) ? "[$suffix]" : ''),
         storage => $storage,
         id      => $service->uuid,
     );

--- a/lib/Myriad/Transport/Redis.pm
+++ b/lib/Myriad/Transport/Redis.pm
@@ -728,7 +728,7 @@ async method del (@keys) {
 }
 
 async method set_unless_exists ($key, $v, $ttl) {
-    $log->infof('Set [%s] to %s with TTL %s', $key, $v, $ttl);
+    $log->tracef('Set [%s] to %s with TTL %s', $key, $v, $ttl);
     await $redis->set(
         $self->apply_prefix($key),
         $v,


### PR DESCRIPTION
This allows a service to have multiple independent mutex instances, for example per emitter or RPC call. The default is still a per-service mutex.