### PR TITLE
Re-try mutex acquisition periodically

### DIFF
--- a/lib/Myriad/Mutex.pm
+++ b/lib/Myriad/Mutex.pm
@@ -72,6 +72,12 @@ async method release {
 }
 
 method DESTROY {
+    if(${^GLOBAL_PHASE} eq 'DESTRUCT') {
+        $log->warnf('Mutex [%s] still acquired at global destruction time', $key)
+            if $acquired;
+        return;
+    }
+
     $self->release->retain;
 }
 

--- a/lib/Myriad/Mutex.pm
+++ b/lib/Myriad/Mutex.pm
@@ -48,12 +48,18 @@ async method acquire {
         ) {
             $log->debugf('Mutex [%s] lost to [%s]', $key, $res);
             my $removed = $storage->when_key_changed($key);
-            await $removed if await $storage->get($key);
+            await Future->wait_any(
+                $self->loop->delay_future(after => 3 + rand),
+                $removed->without_cancel,
+            ) if await $storage->get($key);
         } else {
             $log->debugf('Acquired mutex [%s]', $key);
             $acquired = 1;
             return $self;
         }
+
+        # Slight delay between attempts
+        await $loop->delay_future(after => 0.01 * rand);
     }
 }
 


### PR DESCRIPTION
Even if we have not yet been notified that the key is free, we check again. There are cases where the notification channel may not deliver the key-changed event, for example if we had a Redis server migration while waiting.

We also add a check for mutex-locked-on-exit so we can issue a warning about it.