### PR TITLE
Sublike::Extended as of 0.29+ checks for unexpected parameters

### DIFF
--- a/lib/Myriad/Class.pm
+++ b/lib/Myriad/Class.pm
@@ -296,7 +296,7 @@ sub import {
         List::Util->export($pkg => qw(uniqstr));
         # eval "package $pkg; use Object::Pad::FieldAttr::Checked; use Data::Checks qw(NumGE); 1" or die $@;
         Object::Pad::FieldAttr::Checked->import($pkg);
-        Sublike::Extended->import($pkg);
+        Sublike::Extended->import;
         Signature::Attribute::Checked->import($pkg);
         Data::Checks->import(qw(
             Defined


### PR DESCRIPTION
This has started to throw exceptions when called with unexpected parameters. The fix here is to avoid passing the package - it was previously ignored, and does not do anything useful in the new versions either.

https://metacpan.org/release/PEVANS/XS-Parse-Sublike-0.29/changes