### PR TITLE
Use current instance method for RPC calls

### DIFF
--- a/lib/Myriad/Service/Implementation.pm
+++ b/lib/Myriad/Service/Implementation.pm
@@ -317,7 +317,6 @@ async method load () {
                 sink => $sink
             );
 
-            my $code = $spec->{code};
             $spec->{current} = $sink->source->map($self->$curry::weak(async method ($message) {
                 my $span;
                 if(USE_OPENTELEMETRY) {
@@ -333,7 +332,7 @@ async method load () {
                     if(USE_OPENTELEMETRY) {
                         my $context = OpenTelemetry::Trace->context_with_span($span);
                         dynamically OpenTelemetry::Context->current = $context;
-                        my $response = await $self->$code(
+                        my $response = await $self->$method(
                             $message->args->%*
                         )->on_ready(sub {
                             my $f = shift;
@@ -351,7 +350,7 @@ async method load () {
                         );
                         return $res;
                     } else {
-                        my $response = await $self->$code(
+                        my $response = await $self->$method(
                             $message->args->%*
                         )->on_ready(sub {
                             my $f = shift;


### PR DESCRIPTION
Previously, this would take a snapshot of all the RPC method coderefs, and use those when handling any incoming RPC calls.

The downside of this approach is that it leads to surprising behaviour if you try to override the RPC method with something else later, for example in a method attribute.

We don't really gain anything by doing this - Perl already caches method calls. This commit therefore changes the behaviour to a standard method call keyed by the method name, meaning each RPC call will use whichever method is in the package symbol table.