### PR TITLE
Support for expiry on storage items and hash keys

### DIFF
--- a/lib/Myriad/Role/Storage.pm
+++ b/lib/Myriad/Role/Storage.pm
@@ -46,26 +46,66 @@ a concrete implementation - instead, see classes such as:
 =cut
 
 our @WRITE_METHODS = qw(
-    set
-    getset
+    del
+    expire
     getdel
-    incr
-    push
-    unshift
-    pop
-    shift
-    hash_set
+    getset
     hash_add
+    hash_expire
+    hash_set
+    incr
     orderedset_add
-    orderedset_remove_member
     orderedset_remove_byscore
+    orderedset_remove_member
+    pop
+    push
+    set
+    set_unless_exists
+    shift
+    unlink
     unorderedset_add
     unorderedset_remove
     unorderedset_replace
-    del
-    unlink
-    set_unless_exists
+    unshift
 );
+
+=head2 expire
+
+Apply expiry to a value.
+
+Takes the following parameters:
+
+=over 4
+
+=item * C<< $k >>   - the relative key in storage
+
+=item * C<< $ttl >> - the TTL of a key, Set this to C<undef> to mark it as permanent key.
+
+=back
+
+=cut
+
+method expire;
+
+=head2 hash_expire
+
+Apply expiry to a value in a hash.
+
+Takes the following parameters:
+
+=over 4
+
+=item * C<< $k >>   - the relative key in storage
+
+=item * C<< $hash_key >>   - the hash key
+
+=item * C<< $ttl >> - the TTL to apply, set this to C<undef> to mark it as permanent key.
+
+=back
+
+=cut
+
+method hash_expire;
 
 =head2 set
 

--- a/lib/Myriad/Storage/Implementation/Memory.pm
+++ b/lib/Myriad/Storage/Implementation/Memory.pm
@@ -49,6 +49,14 @@ async method get : Defer ($k) {
     return $data{$k};
 }
 
+async method expire : Defer ($k) {
+    return undef;
+}
+
+async method hash_expire : Defer ($k) {
+    return undef;
+}
+
 =head2 set
 
 Takes the following parameters:

--- a/lib/Myriad/Storage/Implementation/Redis.pm
+++ b/lib/Myriad/Storage/Implementation/Redis.pm
@@ -83,6 +83,14 @@ async method get ($k) {
     await $redis->get($self->apply_prefix($k));
 }
 
+async method expire ($k, $ttl) {
+    await $redis->expire($self->apply_prefix($k), $ttl);
+}
+
+async method hash_expire ($k, $hk, $ttl) {
+    await $redis->hexpire($self->apply_prefix($k), $hk, $ttl);
+}
+
 =head2 set
 
 Takes the following parameters:

--- a/lib/Myriad/Transport/Redis.pm
+++ b/lib/Myriad/Transport/Redis.pm
@@ -738,6 +738,34 @@ async method set ($key, $v, $ttl) {
     await $redis->set($self->apply_prefix($key), $v, defined $ttl ? ('EX', $ttl) : ());
 }
 
+async method expire ($key, $ttl) {
+    if($ttl) {
+        await $redis->expire($self->apply_prefix($key), $ttl);
+    } else {
+        await $redis->persist($self->apply_prefix($key));
+    }
+}
+
+async method hexpire ($key, $hk, $ttl) {
+    my @hk = ref($hk) eq 'ARRAY' ? $hk->@* : $hk;
+    if($ttl) {
+        return await $redis->hexpire(
+            $self->apply_prefix($key),
+            $ttl,
+            qw(fields),
+            0 + @hk,
+            @hk
+        );
+    } else {
+        return await $redis->hpersist(
+            $self->apply_prefix($key),
+            qw(fields),
+            0 + @hk,
+            @hk
+        );
+    }
+}
+
 async method unlink (@keys) {
     await $redis->unlink(map { $self->apply_prefix($_) } @keys);
 }


### PR DESCRIPTION
New storage methods for key and hash key expiry:

- `expire` - marks this item (any type) for expiry after the given number of seconds, use -1 to expire immediately and 0 to disable expiry (keep it forever)
- `hash_expire` - marks this hash key for expiry, as above use -1 to expire immediately and 0 to mark as persistent; hash keys can be provided as a single value or an arrayref of values