### PR TITLE
Provide ->hash_remove storage method

### DIFF
--- a/lib/Myriad/Role/Storage.pm
+++ b/lib/Myriad/Role/Storage.pm
@@ -52,6 +52,7 @@ our @WRITE_METHODS = qw(
     getset
     hash_add
     hash_expire
+    hash_remove
     hash_set
     incr
     orderedset_add
@@ -222,6 +223,22 @@ or C<undef> if none available.
 =cut
 
 method shift;
+
+=head2 hash_remove
+
+Takes the following parameters:
+
+=over 4
+
+=item *
+
+=back
+
+Returns a L<Future> which will resolve to .
+
+=cut
+
+method hash_remove;
 
 =head2 hash_set
 

--- a/lib/Myriad/Storage/Implementation/Memory.pm
+++ b/lib/Myriad/Storage/Implementation/Memory.pm
@@ -267,6 +267,30 @@ async method shift : Defer ($k) {
     return shift $data{$k}->@*;
 }
 
+=head2 hash_remove
+
+Takes the following parameters:
+
+=over 4
+
+=item *
+
+=back
+
+Returns a L<Future> which will resolve to .
+
+=cut
+
+async method hash_remove : Defer ($k, $hash_key) {
+    if(ref $hash_key eq 'ARRAY') {
+        return 0 + delete $data{$k}->@{$hash_key->@*};
+    } else {
+        die 'value cannot be a reference for ' . $k if ref $hash_key;
+        delete $data{$k}->{$hash_key};
+        return 1;
+    }
+}
+
 =head2 hash_set
 
 Takes the following parameters:

--- a/lib/Myriad/Storage/Implementation/Redis.pm
+++ b/lib/Myriad/Storage/Implementation/Redis.pm
@@ -348,6 +348,24 @@ async method hash_get ($k, $hash_key) {
     await $redis->hget($self->apply_prefix($k), $hash_key);
 }
 
+=head2 hash_remove
+
+Takes the following parameters:
+
+=over 4
+
+=item *
+
+=back
+
+Returns a L<Future> indicating success or failure.
+
+=cut
+
+async method hash_remove ($k, $hash_key) {
+    await $redis->hdel($self->apply_prefix($k), ref($hash_key) eq 'ARRAY' ? $hash_key->@* : $hash_key);
+}
+
 =head2 hash_add
 
 Takes the following parameters:

--- a/lib/Myriad/Transport/Redis.pm
+++ b/lib/Myriad/Transport/Redis.pm
@@ -812,6 +812,10 @@ async method lpop($key) {
     await $redis->lpop($self->apply_prefix($key));
 }
 
+async method hdel ($k, @hash_keys) {
+    await $redis->hdel($self->apply_prefix($k), @hash_keys);
+}
+
 async method hset ($k, $hash_key, $v) {
     await $redis->hset($self->apply_prefix($k), $hash_key, $v);
 }


### PR DESCRIPTION
Support for item removal from hashes. The `->hash_remove` method removes a key previously set via `->hash_set`, and can take an arrayref of hash keys if multiple items need to be removed at once.