### PR TITLE
Rethrow exceptions across RPC boundary

### DIFF
--- a/lib/Myriad/RPC/Client/Implementation/Memory.pm
+++ b/lib/Myriad/RPC/Client/Implementation/Memory.pm
@@ -88,6 +88,11 @@ async method call_rpc ($service, $method, %args) {
             $self->loop->timeout_future(at => $deadline),
             $pending
         );
+        if(my $err = $message->response->{error}) {
+            Myriad::Exception::InternalError->new(
+                reason => $err
+            )->throw;
+        }
         return $message->response->{response};
     } catch ($e) {
         if ($e =~ /Timeout/) {

--- a/lib/Myriad/RPC/Client/Implementation/Memory.pm
+++ b/lib/Myriad/RPC/Client/Implementation/Memory.pm
@@ -91,9 +91,13 @@ async method call_rpc ($service, $method, %args) {
         return $message->response->{response};
     } catch ($e) {
         if ($e =~ /Timeout/) {
-            $e  = Myriad::Exception::RPC::Timeout->new(reason => 'deadline is due');
+            $e  = Myriad::Exception::RPC::Timeout->new(
+                reason => 'deadline is due'
+            );
         } else {
-            $e = Myriad::Exception::InternalError->new(reason => $e) unless blessed $e && $e->DOES('Myriad::Exception');
+            $e = Myriad::Exception::InternalError->new(
+                reason => $e
+            ) unless blessed $e && $e->DOES('Myriad::Exception');
         }
         $pending->fail($e);
         delete $pending_requests->{$message_id};

--- a/lib/Myriad/RPC/Client/Implementation/Memory.pm
+++ b/lib/Myriad/RPC/Client/Implementation/Memory.pm
@@ -104,7 +104,7 @@ async method call_rpc ($service, $method, %args) {
                 reason => $e
             ) unless blessed $e && $e->DOES('Myriad::Exception');
         }
-        $pending->fail($e);
+        $pending->fail($e) unless $pending->is_ready;
         delete $pending_requests->{$message_id};
         $e->throw();
     }

--- a/lib/Myriad/RPC/Client/Implementation/Redis.pm
+++ b/lib/Myriad/RPC/Client/Implementation/Redis.pm
@@ -101,13 +101,17 @@ async method call_rpc($service, $method, %args) {
     } catch ($e) {
         $log->warnf('Failed on RPC call - %s', $e);
         if ($e =~ /Timeout/) {
-            $e  = Myriad::Exception::RPC::Timeout->new(reason => 'deadline is due');
+            $e  = Myriad::Exception::RPC::Timeout->new(
+                reason => 'deadline is due'
+            );
         } else {
-            $e = Myriad::Exception::InternalError->new(reason => $e) unless blessed $e && $e->DOES('Myriad::Exception');
+            $e = Myriad::Exception::InternalError->new(
+                reason => $e
+            ) unless blessed $e && $e->DOES('Myriad::Exception');
         }
         $pending->fail($e);
         delete $pending_requests->{$message_id};
-        $e->throw();
+        $e->throw;
     }
 }
 

--- a/lib/Myriad/RPC/Client/Implementation/Redis.pm
+++ b/lib/Myriad/RPC/Client/Implementation/Redis.pm
@@ -114,7 +114,7 @@ async method call_rpc($service, $method, %args) {
                 reason => $e
             ) unless blessed $e && $e->DOES('Myriad::Exception');
         }
-        $pending->fail($e);
+        $pending->fail($e) unless $pending->is_ready;
         delete $pending_requests->{$message_id};
         $e->throw;
     }

--- a/lib/Myriad/RPC/Client/Implementation/Redis.pm
+++ b/lib/Myriad/RPC/Client/Implementation/Redis.pm
@@ -97,6 +97,11 @@ async method call_rpc($service, $method, %args) {
             $pending
         );
 
+        if(my $err = $message->response->{error}) {
+            Myriad::Exception::InternalError->new(
+                reason => $err
+            )->throw;
+        }
         return $message->response->{response};
     } catch ($e) {
         $log->warnf('Failed on RPC call - %s', $e);


### PR DESCRIPTION
If an RPC call fails, the details are placed in the `error` response.

If we're using `->call_rpc` or other wrapper mechanisms, we want those to fail in those cases, so this adds a check for the `{error}` key and uses that to construct an `InternalException` instance. Note that the precise details of the exception are likely to change to accommodate the interoperability requirements for other languages: ideally we'd always raise the same exception class and details as the upstream service threw, but also need to be careful about the following cases:

- custom code in the exception object that isn't available on the caller
- internal errors which should be distinguishable from application errors

For these reasons, we start with an `InternalException` instance in all cases, since we expect calling code to be able to handle that (it can be raised regardless of what the called code is going to do, for example to indicate a transport error). Future updates are likely to add other possible exception responses giving a closer match to the original exception.