### PR TITLE
Provide event bus for services

### DIFF
--- a/lib/Myriad/API.pm
+++ b/lib/Myriad/API.pm
@@ -25,12 +25,14 @@ use Myriad::Config;
 use Myriad::Mutex;
 use Myriad::Service::Remote;
 use Myriad::Service::Storage;
+use Myriad::Service::Bus;
 
 field $myriad;
 field $service;
 field $service_name;
 field $storage;
 field $config;
+field $bus;
 
 =head1 METHODS
 
@@ -122,6 +124,17 @@ async method mutex (@args) {
     } else {
         return await $mutex->acquire;
     }
+}
+
+method bus {
+    unless($bus) {
+        $bus = Myriad::Service::Bus->new(
+            service   => $service_name,
+            myriad    => $myriad,
+        );
+        $bus->setup->retain;
+    }
+    return $bus;
 }
 
 1;

--- a/lib/Myriad/Service/Bus.pm
+++ b/lib/Myriad/Service/Bus.pm
@@ -1,0 +1,28 @@
+package Myriad::Service::Bus;
+
+use Myriad::Class;
+
+field $events : reader;
+field $transport;
+field $service_name;
+
+BUILD (%args) {
+    $service_name = $args{service};
+    $events = $args{myriad}->ryu->source;
+    $transport = $args{myriad}->transport('storage');
+}
+
+async method setup {
+    # We currently pass through the events to the main source, and
+    # don't support backpressure - for small volumes this works, but
+    # the longer-term intention is to decant heavy subscription streams
+    # onto their own connection so we can pause reading without affecting
+    # other functionality.
+    my $sub = await $transport->subscribe('event.{' . $service_name . '}');
+    $sub->each(sub {
+        $events->emit($_);
+    })->retain;
+    return $sub;
+}
+
+1;

--- a/lib/Myriad/Service/Remote.pm
+++ b/lib/Myriad/Service/Remote.pm
@@ -21,6 +21,7 @@ Myriad::Service::Remote - abstraction to access other services over the network.
 use Myriad::Class;
 use Myriad::Service::Storage::Remote;
 use Myriad::Service::Remote::RPC;
+use Myriad::Service::Remote::Bus;
 
 field $myriad;
 field $service_name;
@@ -76,8 +77,14 @@ method rpc () {
     );
 }
 
-=head2 subscribe
+method bus () {
+    return Myriad::Service::Remote::Bus->new(
+        myriad  => $myriad,
+        service => $service_name,
+    );
+}
 
+=head2 subscribe
 
 Please use the C<Receiver> attribute in Myriad.
 
@@ -91,9 +98,9 @@ it subscribes to a channel in the remote service.
 async method subscribe ($channel, $client = "remote_service") {
    my $sink = $myriad->ryu->sink;
    await $myriad->subscription->create_from_sink(
-        sink => $sink,
+        sink    => $sink,
         service => $service_name,
-        client => $client,
+        client  => $client,
         channel => $channel,
     );
    return $sink->source;

--- a/lib/Myriad/Service/Remote/Bus.pm
+++ b/lib/Myriad/Service/Remote/Bus.pm
@@ -1,0 +1,46 @@
+package Myriad::Service::Remote::Bus;
+use Myriad::Class;
+
+# VERSION
+# AUTHORITY
+
+=encoding utf8
+
+=head1 NAME
+
+Myriad::Service::Remote::Bus - abstraction to access events from other services
+
+=head1 SYNOPSIS
+
+
+=head1 DESCRIPTION
+
+=cut
+
+field $myriad : param;
+field $service : param;
+
+field $events;
+
+method events {
+    unless($events) {
+        $events = $myriad->ryu->source;
+        my $transport = $myriad->transport('storage');
+        my $uuid = $service;
+        $events->map(async sub ($item, @) {
+            try {
+                $log->debugf('Post to service [%s] data [%s]', $uuid, $item);
+                await $transport->publish(
+                    'event.{' . $uuid . '}',
+                    ref($item) ? encode_json_utf8($item) : encode_utf8($item)
+                )
+            } catch ($e) {
+                $log->errorf('Failed to send event: %s', $e);
+            }
+        })->resolve(low => 10, high => 100)->retain;
+    }
+    $log->tracef('Returning source: %s', $events);
+    return $events;
+}
+
+1;

--- a/lib/Myriad/Transport/Redis.pm
+++ b/lib/Myriad/Transport/Redis.pm
@@ -714,7 +714,7 @@ Publish a message through a Redis channel (pub/sub system)
 =cut
 
 async method publish ($channel, $message) {
-    await $redis->publish($self->apply_prefix($channel), "$message");
+    await $redis->spublish($self->apply_prefix($channel), "$message");
 }
 
 =head2 subscribe
@@ -725,7 +725,7 @@ Subscribe to a redis channel.
 
 async method subscribe ($channel) {
     my $instance = await $self->borrow_instance_from_pool;
-    await $instance->subscribe($self->apply_prefix($channel))->on_ready(sub {
+    await $instance->ssubscribe($self->apply_prefix($channel))->on_ready(sub {
         $self->return_instance_to_pool($instance);
     });
 }

--- a/lib/Test/Myriad/Service.pm
+++ b/lib/Test/Myriad/Service.pm
@@ -72,7 +72,7 @@ BUILD (%args) {
 
 =head2 add_rpc
 
-Attaches a new RPC to the service with a defaultt response.
+Attaches a new RPC to the service with a default response.
 
 =over 4
 

--- a/t/service-bus.t
+++ b/t/service-bus.t
@@ -1,0 +1,73 @@
+use Myriad::Class;
+
+use Test::More;
+use Test::Deep;
+use Test::Fatal;
+use Test::Myriad;
+use Log::Any::Adapter qw(TAP);
+
+use Future;
+use Future::AsyncAwait;
+use Object::Pad;
+
+package Test::Sender {
+    use Myriad::Service;
+
+    field $bus;
+
+    async method startup {
+        $log->debugf('Startup first');
+        $bus = $api->service_by_name('test.receiver')->bus;
+        $log->debugf('Startup complete');
+    }
+
+    async method send:RPC (%args) {
+        $log->debugf('Calling send with %s', \%args);
+        try {
+            $log->debugf('Send to remote bus');
+            $bus->events->emit($args{data});
+            return;
+        } catch ($e) {
+            $log->errorf('Failed to send - %s', $e);
+        }
+    }
+}
+
+package Test::Receiver {
+   use Myriad::Service;
+
+   field $events = [ ];
+
+   async method startup {
+       $api->bus->events->each(sub ($ev) {
+           $log->debugf('Have event: %s', $ev);
+           push $events->@*, $ev;
+       });
+   }
+   async method events:RPC {
+       return $events;
+   }
+}
+my $sender;
+my $receiver;
+
+BEGIN {
+    $receiver = Test::Myriad->add_service(service => 'Test::Receiver');
+    $sender = Test::Myriad->add_service(service => 'Test::Sender');
+}
+
+try {
+    await Test::Myriad->ready();
+    note 'call RPC';
+    await $sender->call_rpc('send', data => 'test data');
+    note 'check results';
+    my $srv = $Myriad::REGISTRY->service_by_name('test.receiver');
+    my $ev = await $srv->events;
+    note explain $ev;
+    cmp_deeply($ev, bag('test data'), 'have events after sending');
+} catch ($e) {
+    note explain $e;
+    die $e;
+}
+done_testing;
+

--- a/t/service-bus.t
+++ b/t/service-bus.t
@@ -1,7 +1,7 @@
 use Myriad::Class;
 
 use Test::More;
-use Test::Deep;
+use Test::Deep qw(bag cmp_deeply);
 use Test::Fatal;
 use Test::Myriad;
 use Log::Any::Adapter qw(TAP);


### PR DESCRIPTION
This adds a `->bus` method for lightweight notifications between services. It uses the Redis sharded pub/sub mechanism to send notifications between services.