### PR TITLE
Convert blocking RPC streams XREADGROUP to event-driven polling

### DIFF
--- a/lib/Myriad/RPC/Implementation/Redis.pm
+++ b/lib/Myriad/RPC/Implementation/Redis.pm
@@ -50,11 +50,11 @@ field $running;
 field $processing;
 
 sub stream_name_from_service ($service, $method) {
-    return RPC_PREFIX . ".$service.". RPC_SUFFIX . "/$method"
+    return RPC_PREFIX . ".{$service}.". RPC_SUFFIX . "/$method"
 }
 
 sub service_from_stream_name ($stream_name) {
-    my ($service, $method) = $stream_name =~ m{\Q@{[RPC_PREFIX()]}\E\.([^/]+)\.\Q@{[RPC_SUFFIX]}\E/(.*)};
+    my ($service, $method) = $stream_name =~ m{\Q@{[RPC_PREFIX()]}\E\.\{([^\}]+)\}\.\Q@{[RPC_SUFFIX]}\E/(.*)};
     return ($service, $method);
 }
 

--- a/lib/Myriad/RPC/Implementation/Redis.pm
+++ b/lib/Myriad/RPC/Implementation/Redis.pm
@@ -34,17 +34,10 @@ with 'Myriad::Role::RPC';
 
 our @EXPORT_OK = qw(stream_name_from_service);
 
-field $redis;
-method redis { $redis }
-
-field $group_name;
-method group_name { $group_name }
-
-field $whoami;
-method whoami { $whoami }
-
-field $rpc_list;
-method rpc_list { $rpc_list }
+field $redis:reader;
+field $group_name:reader;
+field $whoami:reader;
+field $rpc_list:reader;
 
 field $running;
 field $processing;

--- a/lib/Myriad/Transport/Redis.pm
+++ b/lib/Myriad/Transport/Redis.pm
@@ -261,8 +261,12 @@ async method read_from_stream (%args) {
     );
     my $claim_required = $claimed->[1]->@* ? 1 : 0;
 
+    # Trigger read-invalidation
+    await $self->stream_info(
+        $args{stream}
+    );
     my ($delivery) = await $self->xreadgroup(
-        BLOCK   => $self->wait_time,
+        BLOCK   => 1, # $self->wait_time,
         GROUP   => $group, $client,
         COUNT   => $self->batch_count,
         STREAMS => ($stream, ($claim_required ? '0' : '>')),


### PR DESCRIPTION
As the number of RPC methods increases, we run into issues with the current setup which does a blocking `XREADGROUP`.

Since we have clientside caching available, we can use this to deliver a "stream has new items" event, avoiding the need to block. We trigger this notification by making an `xstream info` call, since `xreadgroup` itself doesn't mark the key as being read.