### PR TITLE
Bug fix: subscribe method should return the payload stream

### DIFF
--- a/lib/Myriad/RPC/Client/Implementation/Redis.pm
+++ b/lib/Myriad/RPC/Client/Implementation/Redis.pm
@@ -41,7 +41,9 @@ method configure (%args) {
 }
 
 method is_started() {
-    return defined $started ? $started : Myriad::Exception::InternalError->new(message => '->start was not called')->throw;
+    return defined($started)
+    ? $started
+    : Myriad::Exception::InternalError->new(message => '->start was not called')->throw;
 }
 
 async method start() {

--- a/lib/Myriad/RPC/Client/Implementation/Redis.pm
+++ b/lib/Myriad/RPC/Client/Implementation/Redis.pm
@@ -49,7 +49,7 @@ method is_started() {
 async method start() {
     $started = $self->loop->new_future(label => 'rpc_client_subscription');
     my $sub = await $redis->subscribe($whoami);
-    $subscription = $sub->events->map('payload')->map(sub{
+    $subscription = $sub->map(sub{
         try {
             my $payload = $_;
             $log->tracef('Received RPC response as %s', $payload);

--- a/lib/Myriad/Transport/Redis.pm
+++ b/lib/Myriad/Transport/Redis.pm
@@ -729,9 +729,10 @@ Subscribe to a redis channel.
 
 async method subscribe ($channel) {
     my $instance = await $self->borrow_instance_from_pool;
-    await $instance->ssubscribe($self->apply_prefix($channel))->on_ready(sub {
+    my $sub = await $instance->ssubscribe($self->apply_prefix($channel))->on_ready(sub {
         $self->return_instance_to_pool($instance);
     });
+    return $sub->events->map('payload');
 }
 
 async method get($key) {


### PR DESCRIPTION
As part of the service bus support, more places are using the `->subscribe` method on the transport. Unfortunately this means that we had some inconsistencies between callers expecting a `Net::Async::Redis::Subscription` instance, and other places just expecting a `Ryu::Source` with the event payloads.

Since this is supposed to be transport-agnostic, we standardise on the latter: `->subscribe` now returns a `Ryu::Source` with the `->payload` event stream in both cases.