### PR TITLE
Some fixes and cleanup for `->when_key_changed` storage method

### DIFF
--- a/lib/Myriad/Transport/Redis.pm
+++ b/lib/Myriad/Transport/Redis.pm
@@ -948,7 +948,7 @@ field $key_watcher;
 method key_watcher {
     $key_watcher ||= $self->clientside_cache_events
         ->each($self->$curry::weak(method {
-            $log->infof('Key change detected for %s', $_);
+            $log->tracef('Key change detected for %s, waiting for %s', $_, [ sort keys $key_change->%* ]);
             $key_change->{$_}->done if $key_change->{$_};
             return;
         }));

--- a/lib/Myriad/Transport/Redis.pm
+++ b/lib/Myriad/Transport/Redis.pm
@@ -949,7 +949,7 @@ method key_watcher {
     $key_watcher ||= $self->clientside_cache_events
         ->each($self->$curry::weak(method {
             $log->tracef('Key change detected for %s, waiting for %s', $_, [ sort keys $key_change->%* ]);
-            $key_change->{$_}->done if $key_change->{$_};
+            $key_change->{$_}->done if $key_change->{$_} and !$key_change->{$_}->is_ready;
             return;
         }));
 }

--- a/lib/Myriad/Transport/Redis.pm
+++ b/lib/Myriad/Transport/Redis.pm
@@ -956,7 +956,7 @@ method key_watcher {
 
 method when_key_changed ($k) {
     $self->key_watcher;
-    my $key = $self->remove_prefix($k);
+    my $key = $k; # we use original key here, since our ->clientside_cache_events watcher automatically removes the prefix
     return +(
         $key_change->{$key} //= $redis->loop->new_future->on_ready(
             $self->$curry::weak(method {


### PR DESCRIPTION
Previous versions had unnecessarily-verbose logging when we receive these events. This has been downgraded to `trace` level.

Additionally, the key prefixes were inconsistent, partly due to functionality duplicated between the storage and transport subsystems.